### PR TITLE
address population of cell and atoms inside topology

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab @ git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git@migrate-top-norm",
-    "nomad-simulations @ git+https://github.com/FAIRmat-NFDI/nomad-simulations.git@migrate-top-norm-2",
     "nomad-simulation-parsers @ git+https://github.com/FAIRmat-NFDI/nomad-parser-plugins-simulation.git@81bc154452c21a680b2e1ff7e43d108a22fe3e55",
     "ase>=3.25.0",
     "python-magic-bin; sys_platform == 'win32'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,10 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.3.0",
-    "nomad-simulations",
-    'ase>=3.25.0',
+    "nomad-lab @ git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git@migrate-top-norm",
+    "nomad-simulations @ git+https://github.com/FAIRmat-NFDI/nomad-simulations.git@migrate-top-norm-2",
+    "nomad-simulation-parsers @ git+https://github.com/FAIRmat-NFDI/nomad-parser-plugins-simulation.git@81bc154452c21a680b2e1ff7e43d108a22fe3e55",
+    "ase>=3.25.0",
     "python-magic-bin; sys_platform == 'win32'",
 ]
 

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -202,6 +202,7 @@ class ResultsNormalizerBase:
 
     def normalize(self, archive: EntryArchive, logger=None) -> None:
         self.entry_archive = archive
+        legacy_delegated = False
 
         # Setup logger
         if logger is not None:
@@ -220,10 +221,12 @@ class ResultsNormalizerBase:
             # old data schema, etc.)
             self.logger.info('Falling back to legacy results normalization')
             self._normalize_with_legacy(archive, self.logger)
+            legacy_delegated = True
 
-        # Always handle measurements (works for both v1 and v2)
-        for measurement in self.entry_archive.measurement:
-            self.normalize_measurement(measurement)
+        # Legacy delegate handles measurements itself.
+        if not legacy_delegated:
+            for measurement in self.entry_archive.measurement:
+                self.normalize_measurement(measurement)
 
         self.entry_archive = None
         self.section_run = None
@@ -238,9 +241,8 @@ class ResultsNormalizerBase:
         if not hasattr(archive, 'data') or archive.data is None:
             return False
 
-        # Check if data has model_system (v2 schema indicator)
-        # if not hasattr(archive.data, 'model_system'):
-        #     return False
+        # Check if data has model_system (Simulation-style v2 schema indicator)
+        has_model_system = hasattr(archive.data, 'model_system')
 
         # Verify it's using basesections.v2 by checking the class origin
         from nomad.datamodel.metainfo.basesections.v2 import System as SystemV2
@@ -249,12 +251,18 @@ class ResultsNormalizerBase:
             return True
 
         # If model_system exists and has items, check if they're v2 System instances
-        if hasattr(archive.data, 'model_system') and archive.data.model_system:
+        if has_model_system and archive.data.model_system:
             # Check if at least one model_system is a v2 System
             return any(isinstance(sys, SystemV2) for sys in archive.data.model_system)
 
-        # If model_system attribute exists but is empty, still consider it v2 schema
-        return True
+        # If model_system attribute exists but is empty, still consider it v2
+        # schema (e.g. partially parsed Simulation).
+        if has_model_system:
+            return True
+
+        # Non-simulation custom data sections (and any other data without
+        # model_system) must go through the legacy fallback path.
+        return False
 
     def _normalize_with_data_schema(self, archive: EntryArchive, logger) -> None:
         """Normalization cascade for v2 data schema (archive.data)."""
@@ -278,24 +286,12 @@ class ResultsNormalizerBase:
         Delegates to the old ResultsNormalizer from nomad-FAIR which handles
         all legacy cases.
         """
-        # Import and delegate to legacy normalizer
+        from nomad.normalizing.results import (
+            ResultsNormalizer as LegacyResultsNormalizer,
+        )
 
-        # Set section_run for compatibility with legacy code
-        try:
-            self.section_run = archive.run[0]
-        except (AttributeError, IndexError):
-            self.section_run = None
-
-        # Initialize results sections
-        results = self.entry_archive.results
-        if results is None:
-            results = self.entry_archive.m_create(Results)
-        if results.properties is None:
-            results.m_create(Properties)
-
-        # Run legacy normalization
-        if self.section_run:
-            self.normalize_run(logger=logger)
+        legacy_normalizer = LegacyResultsNormalizer()
+        legacy_normalizer.normalize(archive, logger)
 
     def normalize_sample(self, sample) -> None:
         material = self.entry_archive.m_setdefault('results.material')

--- a/src/nomad_topology_normalizer/normalizers/topology.py
+++ b/src/nomad_topology_normalizer/normalizers/topology.py
@@ -193,6 +193,7 @@ def add_system_info_2(  # noqa: PLR0912
         topologies: Dict of all topology systems
         parent_system: The parent System with positions and particle_states
     """
+
     def _particle_symbols(states, indices=None) -> list[str]:
         symbols = []
         if not states:
@@ -208,8 +209,9 @@ def add_system_info_2(  # noqa: PLR0912
                 symbols.append(chemical_symbols[state.atomic_number])
         return symbols
 
-    # Root/original node: derive atoms/cell directly from representative v2 ModelSystem.
-    # Keep indices unset because downstream GUI logic uses "no indices" to identify roots.
+    # Root/original node: derive atoms/cell directly from representative
+    # v2 ModelSystem. Keep indices unset because downstream GUI logic uses
+    # "no indices" to identify roots.
     relation = system.system_relation.type if system.system_relation else None
     if relation == 'root' and parent_system is not None:
         try:
@@ -466,7 +468,9 @@ class TopologyNormalizer(Normalizer):
 
             if has_valid_data:
                 topology: dict[str, System] = {}
-                original = get_topology_original(system.particle_states, self.entry_archive)
+                original = get_topology_original(
+                    system.particle_states, self.entry_archive
+                )
                 add_system(original, topology)
                 label_to_indices: dict[str, list] = defaultdict(list)
 

--- a/src/nomad_topology_normalizer/normalizers/topology.py
+++ b/src/nomad_topology_normalizer/normalizers/topology.py
@@ -193,7 +193,53 @@ def add_system_info_2(  # noqa: PLR0912
         topologies: Dict of all topology systems
         parent_system: The parent System with positions and particle_states
     """
-    # Check if indices are available
+    def _particle_symbols(states, indices=None) -> list[str]:
+        symbols = []
+        if not states:
+            return symbols
+        iterable = range(len(states)) if indices is None else indices
+        for idx in iterable:
+            if idx >= len(states):
+                continue
+            state = states[idx]
+            if state.chemical_symbol:
+                symbols.append(state.chemical_symbol)
+            elif state.atomic_number:
+                symbols.append(chemical_symbols[state.atomic_number])
+        return symbols
+
+    # Root/original node: derive atoms/cell directly from representative v2 ModelSystem.
+    # Keep indices unset because downstream GUI logic uses "no indices" to identify roots.
+    relation = system.system_relation.type if system.system_relation else None
+    if relation == 'root' and parent_system is not None:
+        try:
+            particle_states = parent_system.particle_states
+            if system.n_atoms is None and particle_states:
+                system.n_atoms = len(particle_states)
+
+            ase_atoms = parent_system.to_ase_atoms()
+            if ase_atoms is not None:
+                # `results.System.atoms` exists only if runschema support is available.
+                try:
+                    has_atoms_payload = system.atoms is not None
+                except AttributeError:
+                    has_atoms_payload = True
+                if not has_atoms_payload:
+                    system.atoms = nomad_atoms_from_ase_atoms(ase_atoms)
+                if system.cell is None:
+                    system.cell = cell_from_ase_atoms(ase_atoms)
+
+            symbols = _particle_symbols(particle_states)
+            if symbols:
+                formula = atomutils.Formula(''.join(symbols))
+                if system.chemical_composition_reduced is None:
+                    system.chemical_composition_reduced = formula.format('reduced')
+                if system.chemical_composition_hill is None:
+                    system.chemical_composition_hill = formula.format('hill')
+        except Exception:
+            pass
+
+    # Check if indices are available (required for subsystem-specific info)
     if system.indices is None or len(system.indices) == 0:
         return
 
@@ -209,12 +255,12 @@ def add_system_info_2(  # noqa: PLR0912
             system.atomic_fraction = system.n_atoms / parent.n_atoms
 
     # Populate parent system with system info
-    if not parent_system or not hasattr(parent_system, 'particle_states'):
+    if not parent_system:
         return
 
     try:
         particle_states = parent_system.particle_states
-        positions = getattr(parent_system, 'positions', None)
+        positions = parent_system.positions
 
         if not particle_states or len(particle_states) == 0:
             return
@@ -222,16 +268,7 @@ def add_system_info_2(  # noqa: PLR0912
             return
 
         # Extract symbols for formula calculation
-        symbols = []
-        for idx in first_instance:
-            if idx >= len(particle_states):
-                continue
-            state = particle_states[idx]
-            if hasattr(state, 'chemical_symbol') and state.chemical_symbol:
-                symbols.append(state.chemical_symbol)
-            elif hasattr(state, 'atomic_number') and state.atomic_number:
-                symbols.append(chemical_symbols[state.atomic_number])
-
+        symbols = _particle_symbols(particle_states, first_instance)
         if not symbols:
             return
 
@@ -429,7 +466,7 @@ class TopologyNormalizer(Normalizer):
 
             if has_valid_data:
                 topology: dict[str, System] = {}
-                original = get_topology_original(system.particle_states)
+                original = get_topology_original(system.particle_states, self.entry_archive)
                 add_system(original, topology)
                 label_to_indices: dict[str, list] = defaultdict(list)
 

--- a/tests/data/first.archive.yaml
+++ b/tests/data/first.archive.yaml
@@ -1,0 +1,5 @@
+data:
+  m_def: nomad.datamodel.metainfo.basesections.v2.BaseSection
+  formula: CH3NH3I
+  name: test
+  sub_systems: []

--- a/tests/data/second.archive.yaml
+++ b/tests/data/second.archive.yaml
@@ -1,0 +1,22 @@
+data:
+  m_def: nomad.datamodel.metainfo.basesections.v2.System
+  sub_systems:
+    - m_def: nomad.datamodel.metainfo.basesections.v2.NestedSubSystem
+      nested_system:
+        m_def: nomad.datamodel.metainfo.basesections.v2.System
+        formula: PbI2
+      subsystem_properties:
+        m_def: nomad.datamodel.metainfo.basesections.v2.SubSystemProperties
+        atomic_fraction: 0.5
+    - m_def: nomad.datamodel.metainfo.basesections.v2.NestedSubSystem
+      nested_system:
+        m_def: nomad.datamodel.metainfo.basesections.v2.System
+        formula: CsI
+      subsystem_properties:
+        m_def: nomad.datamodel.metainfo.basesections.v2.SubSystemProperties
+        atomic_fraction: 0.25
+    - m_def: nomad.datamodel.metainfo.basesections.v2.SubSystem
+      system: "../uploads/TH6iAZB9T9Gf9XdkhErkjA/archive/YwFrjVbyNYREe5INJ9A6NqWogqP-#/data"  # update upload_id and entry_id
+      subsystem_properties:
+        m_def: nomad.datamodel.metainfo.basesections.v2.SubSystemProperties
+        atomic_fraction: 0.25

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -121,6 +121,24 @@ def test_data_schema_creates_topology(archive_with_data_schema):
     # This test just verifies the path executes without error
 
 
+def test_data_schema_populates_root_topology_cell_and_atoms(archive_with_data_schema):
+    """Root topology node should expose cell metadata for visualization."""
+    normalizer = ResultsNormalizer()
+
+    normalizer.normalize(archive_with_data_schema, LOGGER)
+
+    topology = archive_with_data_schema.results.material.topology
+    assert topology
+
+    root = topology[0]
+    assert root.label == 'original'
+    assert root.indices is None  # root indices remain implicit in v2 schema
+    assert root.cell is not None
+    assert root.cell.a is not None
+    # Needed by structure visualizer root resolution and subsystem downloads
+    assert getattr(root, 'atoms', None) is not None or getattr(root, 'atoms_ref', None)
+
+
 def test_data_schema_priority_over_run(archive_with_data_schema):
     """Test that v2 data schema takes priority when both schemas present."""
     # Add a mock run section to the data schema archive

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 from nomad.datamodel import EntryArchive, EntryMetadata
+from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel.results import Properties, Results
 from nomad.units import ureg
 from nomad.utils import get_logger
@@ -106,6 +107,36 @@ def test_schema_detection_no_schema(archive_empty, caplog):
     ), 'Should log legacy path as fallback'
 
 
+def test_non_simulation_data_schema_uses_legacy_path(caplog):
+    """Custom archive.data without model_system should not use v2 sim path."""
+    archive = EntryArchive(metadata=EntryMetadata())
+    archive.results = Results()
+    archive.results.properties = Properties()
+
+    class CustomData(ArchiveSection):
+        name = None
+
+    archive.data = CustomData()
+
+    normalizer = ResultsNormalizer()
+    caplog.clear()
+
+    try:
+        normalizer.normalize(archive, LOGGER)
+    except Exception:
+        # Legacy path may still fail depending on environment; routing is
+        # tested via logs.
+        pass
+
+    assert any(
+        'legacy results normalization' in record.message for record in caplog.records
+    ), 'Non-simulation archive.data should use legacy path'
+    assert not any(
+        'v2 data schema results normalization' in record.message
+        for record in caplog.records
+    ), 'Non-simulation archive.data should not use v2 sim path'
+
+
 def test_data_schema_creates_topology(archive_with_data_schema):
     """Test that v2 data schema path creates topology."""
     normalizer = ResultsNormalizer()
@@ -181,6 +212,31 @@ def test_normalize_with_data_schema_calls_topology_normalizer(
 
     # Verify TopologyNormalizer.normalize was called
     assert len(normalize_called) > 0, 'TopologyNormalizer.normalize should be called'
+
+
+def test_legacy_path_delegates_to_nomad_fair_results_normalizer(
+    archive_empty, monkeypatch
+):
+    """Legacy fallback should delegate to nomad-FAIR ResultsNormalizer."""
+    from nomad.normalizing.results import ResultsNormalizer as LegacyResultsNormalizer
+
+    called = []
+    original_normalize = LegacyResultsNormalizer.normalize
+
+    def mock_normalize(self, archive, logger=None):
+        called.append(True)
+        return original_normalize(self, archive, logger)
+
+    monkeypatch.setattr(LegacyResultsNormalizer, 'normalize', mock_normalize)
+
+    normalizer = ResultsNormalizer()
+    try:
+        normalizer.normalize(archive_empty, LOGGER)
+    except Exception:
+        # Legacy normalize may fail in minimal fixture; delegation is what matters.
+        pass
+
+    assert called, 'Legacy ResultsNormalizer.normalize should be delegated to'
 
 
 def test_normalize_measurements_still_works(archive_with_data_schema):

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -9,3 +9,35 @@ def test_schema_package():
     normalize_all(entry_archive)
 
     assert entry_archive.data.message == 'Hello Markus!'
+
+
+def test_second_archive_populates_results_material_topology():
+    """Direct v2 System fixture should populate topology with mapped fractions."""
+    test_file = os.path.join('tests', 'data', 'second.archive.yaml')
+    entry_archive = parse(test_file)[0]
+    normalize_all(entry_archive)
+
+    topology = entry_archive.results.material.topology
+    assert topology is not None
+    assert len(topology) == 5
+
+    root = topology[0]
+    imported = topology[1]
+    subsystems = topology[2:]
+
+    assert root.label == 'original'
+    assert root.system_relation.type == 'root'
+    assert root.child_systems == [imported.system_id]
+
+    # The direct SystemV2 entry is imported as a parser node under the root.
+    assert imported.label == 'second'
+    assert imported.parent_system == root.system_id
+    assert len(imported.child_systems) == 3
+
+    assert [node.label for node in subsystems] == [
+        'subsystem',
+        'subsystem',
+        'subsystem',
+    ]
+    assert [node.parent_system for node in subsystems] == [imported.system_id] * 3
+    assert [node.atomic_fraction for node in subsystems] == [0.5, 0.25, 0.25]


### PR DESCRIPTION
Fix v2 topology normalization to restore root topology metadata needed by downstream visualization.

This PR updates the nomad-topology-normalizer v2 (archive.data / nomad-simulations) path so the root topology node (results.material.topology[0], label original) gets populated with derived system metadata, especially cell, using ModelSystem.to_ase_atoms() and the existing cell_from_ase_atoms(...) helper. This restores compatibility with NOMAD UI/visualizer code that relies on results.material.topology[*].cell.

Additional notes:

- Keeps root indices implicit (indices=None) to preserve existing GUI root-node detection logic.
- Removes an attempted atoms_ref propagation for indexed subsystems that caused a metainfo type error in runschema-enabled environments.
- Adds a regression test for v2 root topology cell/atom metadata population.

- Tightens the v2/legacy routing logic so only simulation-style v2 data (archive.data.model_system) and direct basesections.v2.System entries use the plugin v2 path; custom/non-structural archive.data now correctly falls back to the NOMAD legacy ResultsNormalizer.
- Fixes the legacy fallback implementation to actually delegate to nomad.normalizing.results.ResultsNormalizer (previously non-run entries could bypass legacy results normalization).
- Adds regression tests for non-simulation routing and legacy delegation.

- Adds tests for second.archive.yaml test file