### PR TITLE
minor fixes to the migration

### DIFF
--- a/src/nomad_topology_normalizer/normalizers/material.py
+++ b/src/nomad_topology_normalizer/normalizers/material.py
@@ -37,6 +37,7 @@ from nomad_topology_normalizer.normalizers.symmetry_adapter import (
     from_legacy_repr_symmetry,
     from_model_system,
     is_symmetry_data_minimally_complete,
+    wyckoff_sets_from_model_system,
 )
 
 
@@ -252,6 +253,14 @@ class MaterialNormalizer:
         material.symmetry = self.symmetry()
 
         if self.structural_type == 'bulk':
+            # Reuse the crystallographic analysis already performed by
+            # nomad-simulations. MatID remains the topology fallback only when
+            # these material-id inputs are absent or inconsistent.
+            v2_symmetry_data = from_model_system(self.repr_system)
+            if self.spg_number is None:
+                self.spg_number = v2_symmetry_data.get('space_group_number')
+            if self.wyckoff_sets is None:
+                self.wyckoff_sets = wyckoff_sets_from_model_system(self.repr_system)
             if self.spg_number is not None and self.wyckoff_sets is not None:
                 material.material_id = material_id_bulk(
                     self.spg_number, self.wyckoff_sets

--- a/src/nomad_topology_normalizer/normalizers/material.py
+++ b/src/nomad_topology_normalizer/normalizers/material.py
@@ -201,8 +201,12 @@ class MaterialNormalizer:
                     allowed_structural_types = set(
                         Material.m_def.all_quantities['structural_type'].type
                     )
-                    if self.structural_type in allowed_structural_types:
-                        material.structural_type = self.structural_type
+                    compatible_structural_type = {
+                        'molecule': 'molecule / cluster',
+                        'cluster': 'molecule / cluster',
+                    }.get(self.structural_type, self.structural_type)
+                    if compatible_structural_type in allowed_structural_types:
+                        material.structural_type = compatible_structural_type
                 # Get classification from results.material if already set
                 # (TopologyNormalizer runs first and may have set dimensionality)
                 existing_dimensionality = material.dimensionality

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -393,9 +393,13 @@ class ResultsNormalizerBase:
             for setting in settings:
                 setting_name = getattr(getattr(setting, 'm_def', None), 'name', None)
                 if setting_name == 'SelfConsistency':
-                    threshold_change = setting.threshold_change
+                    threshold_change = getattr(setting, 'threshold_change', None)
                     if threshold_change is not None:
-                        threshold_unit = setting.threshold_change_unit
+                        # The current flexible-unit schema returns a Pint quantity
+                        # directly. Older schemas stored a separate unit string.
+                        if getattr(threshold_change, 'units', None) is not None:
+                            return threshold_change
+                        threshold_unit = getattr(setting, 'threshold_change_unit', None)
                         if threshold_unit:
                             try:
                                 return threshold_change * ureg(threshold_unit)
@@ -789,7 +793,13 @@ class ResultsNormalizerBase:
                 self.logger.warning('skipping incompatible greens field', field=name)
                 return False
 
-        gf_type = GreensFunctionsElectronic.m_def.all_quantities['tau'].type
+        # The legacy Green's-function payload quantities were removed from the
+        # current results schema. Skip this compatibility mapping when they are
+        # unavailable instead of failing every output normalization.
+        tau_quantity = GreensFunctionsElectronic.m_def.all_quantities.get('tau')
+        if tau_quantity is None:
+            return None
+        gf_type = tau_quantity.type
         gf_cls = gf_type.target_quantity_def.m_parent.section_cls
         available_fields = set(gf_cls.m_def.all_quantities.keys())
         legacy_gf = gf_cls()

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -860,8 +860,10 @@ class ResultsNormalizerBase:
                 setattr(legacy_gf, axis_name, axis_value)
                 return True
             except Exception:
-                legacy_gf.m_unset(payload_name)
-                legacy_gf.m_unset(axis_name)
+                # MSection has no m_unset API. Passing None to m_set is the
+                # supported overwrite-mode mechanism for clearing a property.
+                legacy_gf.m_set(payload_name, None)
+                legacy_gf.m_set(axis_name, None)
                 self.logger.warning(
                     'skipping incompatible greens axis/payload pair',
                     axis=axis_name,

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -163,6 +163,9 @@ from nomad_topology_normalizer.normalizers.method import MethodNormalizer
 re_label = re.compile('^([a-zA-Z][a-zA-Z]?)[^a-zA-Z]*')
 elements = set(ase.data.chemical_symbols)
 
+V2_COMPATIBILITY_LABEL = 'nomad-topology-normalizer:v2-compatibility'
+V2_COMPATIBILITY_RUN_ID = f'{V2_COMPATIBILITY_LABEL}:run'
+
 
 def valid_array(array: Any) -> bool:
     """Checks if the given variable is a non-empty array."""
@@ -624,20 +627,90 @@ class ResultsNormalizerBase:
             'values': values,
         }
 
-    def _ensure_legacy_run_calculation(self, archive: EntryArchive):
-        """Ensure archive.run[0].calculation[0] exists.
+    @staticmethod
+    def _compatibility_label(model_method_ref=None) -> str:
+        method_name = getattr(getattr(model_method_ref, 'm_def', None), 'name', None)
+        if method_name:
+            return f'{V2_COMPATIBILITY_LABEL}:{method_name}'
+        return V2_COMPATIBILITY_LABEL
 
-        Used for DOS compatibility payloads.
-        """
+    @staticmethod
+    def _is_compatibility_section(section) -> bool:
+        try:
+            label = getattr(section, 'label', None)
+            if isinstance(label, str) and label.startswith(V2_COMPATIBILITY_LABEL):
+                return True
+            provenance = getattr(section, 'provenance', None)
+            provenance_label = getattr(provenance, 'label', None)
+            return isinstance(provenance_label, str) and provenance_label.startswith(
+                V2_COMPATIBILITY_LABEL
+            )
+        except Exception:
+            return False
+
+    def _remove_generated_compatibility_results(self, properties: Properties) -> None:
+        """Remove only compatibility sections created by this normalizer."""
+        electronic = properties.electronic
+        if electronic is not None:
+            for name in (
+                'band_gap',
+                'dos_electronic',
+                'band_structure_electronic',
+                'greens_functions_electronic',
+            ):
+                sections = getattr(electronic, name, None) or []
+                setattr(
+                    electronic,
+                    name,
+                    [
+                        section
+                        for section in sections
+                        if not self._is_compatibility_section(section)
+                    ],
+                )
+
+        spectroscopic = properties.spectroscopic
+        if spectroscopic is not None:
+            spectroscopic.spectra = [
+                section
+                for section in spectroscopic.spectra or []
+                if not self._is_compatibility_section(section)
+            ]
+
+        structural = properties.structural
+        if structural is not None:
+            structural.radius_of_gyration = [
+                section
+                for section in structural.radius_of_gyration or []
+                if not self._is_compatibility_section(section)
+            ]
+
+        thermodynamic = properties.thermodynamic
+        if thermodynamic is not None:
+            thermodynamic.trajectory = [
+                section
+                for section in thermodynamic.trajectory or []
+                if not self._is_compatibility_section(section)
+            ]
+
+    def _ensure_legacy_run_calculation(
+        self, archive: EntryArchive
+    ) -> tuple[Any, int, int] | None:
+        """Return a dedicated, normalizer-owned compatibility calculation."""
         if not runschema:
             return None
 
-        run = None
-        runs = archive.run
-        if runs and len(runs) > 0:
-            run = runs[0]
-        else:
-            run = runschema.run.Run()
+        runs = archive.run or []
+        run = next(
+            (
+                candidate
+                for candidate in runs
+                if getattr(candidate, 'raw_id', None) == V2_COMPATIBILITY_RUN_ID
+            ),
+            None,
+        )
+        if run is None:
+            run = runschema.run.Run(raw_id=V2_COMPATIBILITY_RUN_ID)
             archive.run.append(run)
 
         calculations = run.calculation
@@ -647,7 +720,11 @@ class ResultsNormalizerBase:
             calculation = runschema.calculation.Calculation()
             run.calculation.append(calculation)
 
-        return calculation
+        return (
+            calculation,
+            list(archive.run).index(run),
+            list(run.calculation).index(calculation),
+        )
 
     def _map_band_structure(
         self, band_structure_section
@@ -669,39 +746,6 @@ class ResultsNormalizerBase:
             energies_array = energies_array[np.newaxis, :, np.newaxis]
         elif energies_array.ndim == 2:
             energies_array = energies_array[np.newaxis, :, :]
-
-        def _resample_k_points(points, n_target: int):
-            """Resample piecewise-linear k-path points to `n_target` samples."""
-            if n_target <= 0:
-                return points
-            try:
-                pts = np.array(points, dtype=float)
-            except Exception:
-                return points
-            if pts.ndim != 2 or pts.shape[1] != 3:
-                return points
-            if pts.shape[0] == n_target:
-                return pts
-            if pts.shape[0] == 1:
-                return np.repeat(pts, n_target, axis=0)
-
-            deltas = np.linalg.norm(np.diff(pts, axis=0), axis=1)
-            cumulative = np.concatenate(([0.0], np.cumsum(deltas)))
-            total = cumulative[-1]
-            if total <= 0:
-                return np.repeat(pts[:1], n_target, axis=0)
-
-            targets = np.linspace(0.0, total, n_target)
-            resampled = np.empty((n_target, 3), dtype=float)
-            seg = 0
-            for i, target in enumerate(targets):
-                while seg < len(cumulative) - 2 and target > cumulative[seg + 1]:
-                    seg += 1
-                start = cumulative[seg]
-                end = cumulative[seg + 1]
-                alpha = 0.0 if end <= start else (target - start) / (end - start)
-                resampled[i] = pts[seg] * (1.0 - alpha) + pts[seg + 1] * alpha
-            return resampled
 
         segment_cls = BandEnergies
         if runschema and hasattr(runschema, 'calculation'):
@@ -738,10 +782,16 @@ class ResultsNormalizerBase:
             # Legacy/GUI path requires kpoints for distance axis construction.
             return None
 
-        # GUI assumes k-point and energy axes have matching length.
+        # A vertex-only or otherwise incomplete path cannot be reconstructed
+        # without knowing the parser's segment sampling and discontinuities.
         n_energy_kpoints = int(energies_array.shape[1])
         if np.array(k_points).shape[0] != n_energy_kpoints:
-            k_points = _resample_k_points(k_points, n_energy_kpoints)
+            self.logger.warning(
+                'skipping band structure with mismatched k-point and energy axes',
+                n_kpoints=int(np.array(k_points).shape[0]),
+                n_energy_kpoints=n_energy_kpoints,
+            )
+            return None
         legacy_segment.kpoints = k_points
 
         reciprocal_cell = band_structure_section.reciprocal_cell
@@ -793,6 +843,32 @@ class ResultsNormalizerBase:
                 self.logger.warning('skipping incompatible greens field', field=name)
                 return False
 
+        def _safe_set_axis_payload(
+            axis_name: str, axis_value, payload_name: str, payload_value
+        ) -> bool:
+            """Set an axis only when its corresponding physical payload is valid."""
+            converted_payload = _to_array_quantity(payload_value)
+            if converted_payload is None:
+                return False
+            if (
+                axis_name not in available_fields
+                or payload_name not in available_fields
+            ):
+                return False
+            try:
+                setattr(legacy_gf, payload_name, converted_payload)
+                setattr(legacy_gf, axis_name, axis_value)
+                return True
+            except Exception:
+                legacy_gf.m_unset(payload_name)
+                legacy_gf.m_unset(axis_name)
+                self.logger.warning(
+                    'skipping incompatible greens axis/payload pair',
+                    axis=axis_name,
+                    payload=payload_name,
+                )
+                return False
+
         # The legacy Green's-function payload quantities were removed from the
         # current results schema. Skip this compatibility mapping when they are
         # unavailable instead of failing every output normalization.
@@ -803,7 +879,7 @@ class ResultsNormalizerBase:
         gf_cls = gf_type.target_quantity_def.m_parent.section_cls
         available_fields = set(gf_cls.m_def.all_quantities.keys())
         legacy_gf = gf_cls()
-        mapped = False
+        payload_mapped = False
 
         for greens in output_section.electronic_greens_functions or []:
             if (
@@ -811,11 +887,14 @@ class ResultsNormalizerBase:
                 and valid_array(greens.imaginary_time.points)
                 and greens.value is not None
             ):
-                mapped = (
-                    _safe_set(legacy_gf, 'tau', greens.imaginary_time.points) or mapped
-                )
-                mapped = (
-                    _safe_set(legacy_gf, 'greens_function_tau', greens.value) or mapped
+                payload_mapped = (
+                    _safe_set_axis_payload(
+                        'tau',
+                        greens.imaginary_time.points,
+                        'greens_function_tau',
+                        greens.value,
+                    )
+                    or payload_mapped
                 )
             if (
                 greens.matsubara_frequency is not None
@@ -828,39 +907,28 @@ class ResultsNormalizerBase:
                         'skipping complex matsubara greens payload in results mapping'
                     )
                     continue
-                mapped = (
-                    _safe_set(legacy_gf, 'matsubara_freq', matsubara_points) or mapped
-                )
-                greens_value = _to_array_quantity(greens.value)
-                if greens_value is None:
-                    continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
+                payload_mapped = (
+                    _safe_set_axis_payload(
+                        'matsubara_freq',
+                        matsubara_points,
                         'greens_function_iw',
-                        greens_value,
+                        greens.value,
                     )
-                    or mapped
+                    or payload_mapped
                 )
             if (
                 greens.real_frequency is not None
                 and valid_array(greens.real_frequency.points)
                 and greens.value is not None
             ):
-                mapped = (
-                    _safe_set(legacy_gf, 'frequencies', greens.real_frequency.points)
-                    or mapped
-                )
-                greens_value = _to_array_quantity(greens.value)
-                if greens_value is None:
-                    continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
+                payload_mapped = (
+                    _safe_set_axis_payload(
+                        'frequencies',
+                        greens.real_frequency.points,
                         'greens_function_freq',
-                        greens_value,
+                        greens.value,
                     )
-                    or mapped
+                    or payload_mapped
                 )
 
         for self_energy in output_section.electronic_self_energies or []:
@@ -872,46 +940,28 @@ class ResultsNormalizerBase:
                 matsubara_points = self_energy.matsubara_frequency.points
                 if np.iscomplexobj(np.array(matsubara_points.magnitude)):
                     continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
+                payload_mapped = (
+                    _safe_set_axis_payload(
                         'matsubara_freq',
                         matsubara_points,
-                    )
-                    or mapped
-                )
-                self_energy_value = _to_array_quantity(self_energy.value)
-                if self_energy_value is None:
-                    continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
                         'self_energy_iw',
-                        self_energy_value,
+                        self_energy.value,
                     )
-                    or mapped
+                    or payload_mapped
                 )
             if (
                 self_energy.real_frequency is not None
                 and valid_array(self_energy.real_frequency.points)
                 and self_energy.value is not None
             ):
-                mapped = (
-                    _safe_set(
-                        legacy_gf, 'frequencies', self_energy.real_frequency.points
-                    )
-                    or mapped
-                )
-                self_energy_value = _to_array_quantity(self_energy.value)
-                if self_energy_value is None:
-                    continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
+                payload_mapped = (
+                    _safe_set_axis_payload(
+                        'frequencies',
+                        self_energy.real_frequency.points,
                         'self_energy_freq',
-                        self_energy_value,
+                        self_energy.value,
                     )
-                    or mapped
+                    or payload_mapped
                 )
 
         for hybridization in output_section.hybridization_functions or []:
@@ -923,60 +973,46 @@ class ResultsNormalizerBase:
                 matsubara_points = hybridization.matsubara_frequency.points
                 if np.iscomplexobj(np.array(matsubara_points.magnitude)):
                     continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
-                        'matsubara_freq',
-                        matsubara_points,
-                    )
-                    or mapped
-                )
-                hybridization_value = _to_array_quantity(hybridization.value)
-                if hybridization_value is None:
-                    continue
                 if 'hybridization_function_iw' in available_fields:
-                    mapped = (
-                        _safe_set(
-                            legacy_gf,
+                    payload_mapped = (
+                        _safe_set_axis_payload(
+                            'matsubara_freq',
+                            matsubara_points,
                             'hybridization_function_iw',
-                            hybridization_value,
+                            hybridization.value,
                         )
-                        or mapped
+                        or payload_mapped
                     )
             if (
                 hybridization.real_frequency is not None
                 and valid_array(hybridization.real_frequency.points)
                 and hybridization.value is not None
             ):
-                mapped = (
-                    _safe_set(
-                        legacy_gf, 'frequencies', hybridization.real_frequency.points
-                    )
-                    or mapped
-                )
-                hybridization_value = _to_array_quantity(hybridization.value)
-                if hybridization_value is None:
-                    continue
-                mapped = (
-                    _safe_set(
-                        legacy_gf,
+                payload_mapped = (
+                    _safe_set_axis_payload(
+                        'frequencies',
+                        hybridization.real_frequency.points,
                         'hybridization_function_freq',
-                        hybridization_value,
+                        hybridization.value,
                     )
-                    or mapped
+                    or payload_mapped
                 )
 
         for qp_weight in output_section.quasiparticle_weights or []:
             if qp_weight.value is not None and valid_array(np.array(qp_weight.value)):
-                legacy_gf.quasiparticle_weights = qp_weight.value
-                mapped = True
+                payload_mapped = (
+                    _safe_set(legacy_gf, 'quasiparticle_weights', qp_weight.value)
+                    or payload_mapped
+                )
 
         chemical_potentials = output_section.chemical_potentials or []
         if chemical_potentials and chemical_potentials[0].value is not None:
-            legacy_gf.chemical_potential = chemical_potentials[0].value
-            mapped = True
+            payload_mapped = (
+                _safe_set(legacy_gf, 'chemical_potential', chemical_potentials[0].value)
+                or payload_mapped
+            )
 
-        if not mapped:
+        if not payload_mapped:
             return None
 
         greens_functions = GreensFunctionsElectronic()
@@ -1101,7 +1137,7 @@ class ResultsNormalizerBase:
             except Exception:
                 return False
 
-            if energies in (None, ''):
+            if energies is None or (isinstance(energies, str) and not energies):
                 return False
             if not totals:
                 return False
@@ -1122,6 +1158,18 @@ class ResultsNormalizerBase:
                         dos for dos in existing_dos if _is_valid_legacy_dos_entry(dos)
                     ]
 
+        self._remove_generated_compatibility_results(properties)
+        if runschema:
+            for compatibility_run in archive.run or []:
+                if (
+                    getattr(compatibility_run, 'raw_id', None)
+                    != V2_COMPATIBILITY_RUN_ID
+                ):
+                    continue
+                for compatibility_calculation in compatibility_run.calculation or []:
+                    compatibility_calculation.dos_electronic = []
+                    compatibility_calculation.band_structure_electronic = []
+
         # Geometry optimization workflow metadata is consumed directly by the
         # geometry optimization card and should be available even when there is
         # no electronic/spectroscopic payload in outputs.
@@ -1138,17 +1186,14 @@ class ResultsNormalizerBase:
 
         had_dos_input = any(len(output.electronic_dos or []) > 0 for output in outputs)
 
-        # Keep legacy-equivalent behavior: electronic properties should represent
-        # the latest relevant output payload, while trajectory/spectra can aggregate.
+        # Electronic properties are selected as one coherent source group. Outputs
+        # with different explicit system/method references must not be combined.
         latest_band_gaps: list[BandGap] = []
         latest_dos_sections: list[DOSElectronic] = []
         latest_dos_payload: list[dict] = []
         latest_band_structures: list[BandStructureElectronic] = []
         latest_greens_functions: list[GreensFunctionsElectronic] = []
-        best_band_gap_score = -1
-        best_dos_score = -1
-        best_band_structure_score = -1
-        best_greens_score = -1
+        electronic_groups: dict[tuple[int | None, int | None], dict[str, Any]] = {}
         spectra_sections: list[Spectra] = []
         rg_sections: list[RadiusOfGyration] = []
         temperature_series: list[float] = []
@@ -1186,6 +1231,9 @@ class ResultsNormalizerBase:
             output_band_structures: list[BandStructureElectronic] = []
             output_greens_functions: list[GreensFunctionsElectronic] = []
             output_highest_occupied = None
+            output_system_ref = output.model_system_ref
+            output_method_ref = output.model_method_ref
+            compatibility_label = self._compatibility_label(output_method_ref)
 
             for band_structure in output.electronic_band_structures or []:
                 output_highest_occupied = band_structure.highest_occupied
@@ -1208,6 +1256,12 @@ class ResultsNormalizerBase:
                 bg_result = BandGap()
                 bg_result.value = bg.value
                 bg_result.type = bg.type
+                if runschema:
+                    bg_result.provenance = (
+                        runschema.calculation.ElectronicStructureProvenance(
+                            label=compatibility_label
+                        )
+                    )
                 if output_highest_occupied is not None:
                     bg_result.energy_highest_occupied = output_highest_occupied
                     bg_result.energy_lowest_unoccupied = (
@@ -1230,6 +1284,7 @@ class ResultsNormalizerBase:
                 ]
                 if totals:
                     dos_result = DOSElectronic()
+                    dos_result.label = compatibility_label
                     dos_result.energies = dos_data_sections[0]['energies_ref']
                     dos_result.total = totals
                     dos_result.spin_polarized = len(dos_data_sections) == 2
@@ -1243,6 +1298,7 @@ class ResultsNormalizerBase:
             for band_structure in output.electronic_band_structures or []:
                 mapped_band_structure = self._map_band_structure(band_structure)
                 if mapped_band_structure:
+                    mapped_band_structure.label = compatibility_label
                     output_band_structures.append(mapped_band_structure)
 
             # Ensure compatibility card consumers can read a complete band-gap
@@ -1278,6 +1334,7 @@ class ResultsNormalizerBase:
 
             mapped_greens_functions = self._map_greens_functions(output)
             if mapped_greens_functions:
+                mapped_greens_functions.label = compatibility_label
                 output_greens_functions.append(mapped_greens_functions)
 
             if (
@@ -1286,64 +1343,74 @@ class ResultsNormalizerBase:
                 or output_band_structures
                 or output_greens_functions
             ):
-                output_system_ref = output.model_system_ref
-                score = (
-                    1
-                    if representative_system is not None
-                    and output_system_ref is representative_system
-                    else 0
+                group_key = (
+                    id(output_system_ref) if output_system_ref is not None else None,
+                    id(output_method_ref) if output_method_ref is not None else None,
                 )
-
-                # Select the best source independently per electronic property
-                # so split-output payloads are merged instead of overwritten.
-                if output_band_gaps and (
-                    score > best_band_gap_score or score == best_band_gap_score
-                ):
-                    best_band_gap_score = score
-                    latest_band_gaps = output_band_gaps
-
-                if output_dos_sections and (
-                    score > best_dos_score or score == best_dos_score
-                ):
-                    best_dos_score = score
-                    latest_dos_sections = output_dos_sections
-                    latest_dos_payload = dos_data_sections
-
-                if output_band_structures and (
-                    score > best_band_structure_score
-                    or score == best_band_structure_score
-                ):
-                    best_band_structure_score = score
-                    latest_band_structures = output_band_structures
-
-                if output_greens_functions and (
-                    score > best_greens_score or score == best_greens_score
-                ):
-                    best_greens_score = score
-                    latest_greens_functions = output_greens_functions
+                group = electronic_groups.setdefault(
+                    group_key,
+                    {
+                        'model_system_ref': output_system_ref,
+                        'model_method_ref': output_method_ref,
+                        'last_index': index,
+                        'band_gaps': [],
+                        'dos_sections': [],
+                        'dos_payload': [],
+                        'band_structures': [],
+                        'greens_functions': [],
+                    },
+                )
+                group['last_index'] = index
+                if output_band_gaps:
+                    group['band_gaps'] = output_band_gaps
+                if output_dos_sections:
+                    group['dos_sections'] = output_dos_sections
+                    group['dos_payload'] = dos_data_sections
+                if output_band_structures:
+                    group['band_structures'] = output_band_structures
+                if output_greens_functions:
+                    group['greens_functions'] = output_greens_functions
 
             for absorption in output.absorption_spectra or []:
                 mapped_spectrum = self._map_spectrum(absorption, 'unavailable')
                 if mapped_spectrum:
+                    mapped_spectrum.provenance = SpectraProvenance(
+                        label=compatibility_label
+                    )
                     spectra_sections.append(mapped_spectrum)
             for xas in output.xas_spectra or []:
                 mapped_spectrum = self._map_spectrum(xas, 'XAS')
                 if mapped_spectrum:
+                    mapped_spectrum.provenance = SpectraProvenance(
+                        label=compatibility_label
+                    )
                     spectra_sections.append(mapped_spectrum)
 
             for rg in output.radii_of_gyration or []:
                 mapped_rg = self._map_radius_of_gyration(rg)
                 if mapped_rg:
+                    mapped_rg.provenance = MDProvenance(label=compatibility_label)
                     rg_sections.append(mapped_rg)
 
-            point_time = output.wall_end
-            if point_time is None:
-                point_time = float(index)
+            point_time = getattr(output, 'time', None)
+            if point_time is not None:
+                try:
+                    point_time = float(point_time.to('second').magnitude)
+                except Exception:
+                    self.logger.warning(
+                        'skipping trajectory point with invalid physical time',
+                        output_index=index,
+                    )
+                    point_time = None
 
             temperatures = output.temperatures or []
-            if temperatures and temperatures[0].value is not None:
+            if (
+                point_time is not None
+                and temperatures
+                and temperatures[0].value is not None
+            ):
                 temperature_series.append(float(temperatures[0].value.magnitude))
-                temperature_time.append(float(point_time))
+                temperature_time.append(point_time)
 
             potential_energies = output.potential_energies or []
             total_energies = output.total_energies or []
@@ -1354,9 +1421,45 @@ class ResultsNormalizerBase:
                 if total_energies
                 else None
             )
-            if energy_source is not None and energy_source.value is not None:
+            if (
+                point_time is not None
+                and energy_source is not None
+                and energy_source.value is not None
+            ):
                 potential_energy_series.append(float(energy_source.value.magnitude))
-                potential_energy_time.append(float(point_time))
+                potential_energy_time.append(point_time)
+
+        if electronic_groups:
+            # Prefer the representative system, then explicit provenance, then the
+            # latest output group. All electronic properties come from this one group.
+            def _group_score(group: dict[str, Any]) -> tuple[int, int, int, int]:
+                return (
+                    int(
+                        representative_system is not None
+                        and group['model_system_ref'] is representative_system
+                    ),
+                    int(group['model_method_ref'] is not None),
+                    int(group['model_system_ref'] is not None),
+                    group['last_index'],
+                )
+
+            selected_group = max(electronic_groups.values(), key=_group_score)
+            latest_band_gaps = selected_group['band_gaps']
+            latest_dos_sections = selected_group['dos_sections']
+            latest_dos_payload = selected_group['dos_payload']
+            latest_band_structures = selected_group['band_structures']
+            latest_greens_functions = selected_group['greens_functions']
+
+            if len(electronic_groups) > 1:
+                self.logger.warning(
+                    'discarding alternate electronic output source groups',
+                    selected_method=getattr(
+                        getattr(selected_group['model_method_ref'], 'm_def', None),
+                        'name',
+                        None,
+                    ),
+                    discarded_groups=len(electronic_groups) - 1,
+                )
 
         if not (
             latest_band_gaps
@@ -1386,8 +1489,9 @@ class ResultsNormalizerBase:
         # Prefer run/calculation DOS compatibility paths when runschema is available,
         # so legacy GUI resolvers can follow runschema-typed references robustly.
         if runschema and latest_dos_sections and latest_dos_payload:
-            calculation = self._ensure_legacy_run_calculation(archive)
-            if calculation is not None:
+            compatibility_target = self._ensure_legacy_run_calculation(archive)
+            if compatibility_target is not None:
+                calculation, run_index, calculation_index = compatibility_target
                 calculation.dos_electronic = []
                 run_total_refs: list[str] = []
                 for idx, dos_entry in enumerate(latest_dos_payload):
@@ -1401,20 +1505,23 @@ class ResultsNormalizerBase:
 
                     calculation.dos_electronic.append(legacy_dos)
                     run_total_refs.append(
-                        f'/run/0/calculation/0/dos_electronic/{idx}/total/0'
+                        f'/run/{run_index}/calculation/{calculation_index}'
+                        f'/dos_electronic/{idx}/total/0'
                     )
 
-                latest_dos_sections[
-                    0
-                ].energies = '/run/0/calculation/0/dos_electronic/0/energies'
+                latest_dos_sections[0].energies = (
+                    f'/run/{run_index}/calculation/{calculation_index}'
+                    '/dos_electronic/0/energies'
+                )
                 latest_dos_sections[0].total = run_total_refs
 
         # `results.properties.electronic.band_structure_electronic.segment` is a
         # reference-typed quantity. For valid references, materialize compatible
         # legacy sections under run/calculation and point results segments there.
         if runschema and latest_band_structures:
-            calculation = self._ensure_legacy_run_calculation(archive)
-            if calculation is not None:
+            compatibility_target = self._ensure_legacy_run_calculation(archive)
+            if compatibility_target is not None:
+                calculation, _, _ = compatibility_target
                 calculation.band_structure_electronic = []
                 run_band_structures: list[BandStructureElectronic] = []
                 for band_structure in latest_band_structures:
@@ -1433,6 +1540,7 @@ class ResultsNormalizerBase:
                     calculation.band_structure_electronic.append(legacy_bs)
 
                     bs_result = BandStructureElectronic()
+                    bs_result.label = band_structure.label
                     bs_result.spin_polarized = band_structure.spin_polarized
                     bs_result.energy_fermi = band_structure.energy_fermi
                     bs_result.reciprocal_cell = band_structure.reciprocal_cell
@@ -1450,14 +1558,6 @@ class ResultsNormalizerBase:
             electronic = properties.electronic
             if electronic is None:
                 electronic = properties.m_create(ElectronicProperties)
-
-            # In v2 mapping mode, these compatibility sections are authoritative.
-            # Replace pre-existing values to avoid leaving malformed stale entries
-            # that can break downstream GUI resolvers.
-            electronic.band_gap = []
-            electronic.dos_electronic = []
-            electronic.band_structure_electronic = []
-            electronic.greens_functions_electronic = []
 
             for band_gap in latest_band_gaps:
                 electronic.m_add_sub_section(ElectronicProperties.band_gap, band_gap)
@@ -1494,7 +1594,9 @@ class ResultsNormalizerBase:
             thermodynamic = properties.thermodynamic
             if thermodynamic is None:
                 thermodynamic = properties.m_create(ThermodynamicProperties)
-            trajectory = Trajectory()
+            trajectory = Trajectory(
+                provenance=MDProvenance(label=V2_COMPATIBILITY_LABEL)
+            )
             available_properties: list[str] = []
             if temperature_series:
                 trajectory.temperature = TemperatureDynamic(

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -1231,7 +1231,6 @@ class ResultsNormalizerBase:
         # with different explicit system/method references must not be combined.
         latest_band_gaps: list[BandGap] = []
         latest_dos_sections: list[DOSElectronic] = []
-        latest_dos_payload: list[dict] = []
         latest_band_structures: list[BandStructureElectronic] = []
         latest_greens_functions: list[GreensFunctionsElectronic] = []
         electronic_groups: dict[tuple[int | None, int | None], dict[str, Any]] = {}
@@ -1241,6 +1240,7 @@ class ResultsNormalizerBase:
         temperature_time: list[float] = []
         potential_energy_series: list[float] = []
         potential_energy_time: list[float] = []
+        outputs_dropped_without_time = 0
 
         representative_system = None
         try:
@@ -1415,17 +1415,13 @@ class ResultsNormalizerBase:
             for absorption in output.absorption_spectra or []:
                 mapped_spectrum = self._map_spectrum(absorption, 'unavailable')
                 if mapped_spectrum and method_label:
-                    mapped_spectrum.provenance = SpectraProvenance(
-                        label=method_label
-                    )
+                    mapped_spectrum.provenance = SpectraProvenance(label=method_label)
                 if mapped_spectrum:
                     spectra_sections.append(mapped_spectrum)
             for xas in output.xas_spectra or []:
                 mapped_spectrum = self._map_spectrum(xas, 'XAS')
                 if mapped_spectrum and method_label:
-                    mapped_spectrum.provenance = SpectraProvenance(
-                        label=method_label
-                    )
+                    mapped_spectrum.provenance = SpectraProvenance(label=method_label)
                 if mapped_spectrum:
                     spectra_sections.append(mapped_spectrum)
 
@@ -1473,36 +1469,70 @@ class ResultsNormalizerBase:
                 potential_energy_series.append(float(energy_source.value.magnitude))
                 potential_energy_time.append(point_time)
 
+            if point_time is None and (temperatures or energy_source is not None):
+                outputs_dropped_without_time += 1
+
+        if outputs_dropped_without_time:
+            # `time` only exists on `TrajectoryOutputs`. A trajectory axis cannot be
+            # invented from the output index, so the series is dropped rather than
+            # plotted against a fabricated time - but never silently.
+            self.logger.warning(
+                'skipping trajectory series without physical time; '
+                'temperature/energy outputs are only mapped for TrajectoryOutputs '
+                'carrying `time`',
+                n_outputs=outputs_dropped_without_time,
+            )
+
+        selected_groups: list[dict[str, Any]] = []
         if electronic_groups:
-            # Prefer the representative system, then explicit provenance, then the
-            # latest output group. All electronic properties come from this one group.
-            def _group_score(group: dict[str, Any]) -> tuple[int, int, int, int]:
-                return (
-                    int(
-                        representative_system is not None
-                        and group['model_system_ref'] is representative_system
-                    ),
-                    int(group['model_method_ref'] is not None),
-                    int(group['model_system_ref'] is not None),
-                    group['last_index'],
+            # Outputs describing different systems must not be combined. Different
+            # methods on the same system are a different matter: legacy
+            # `get_gw_workflow_properties` publishes DFT and GW results side by
+            # side, so keep one labelled section per method instead of one overall.
+            def _system_key(group: dict[str, Any]) -> int | None:
+                system_ref = group['model_system_ref']
+                return id(system_ref) if system_ref is not None else None
+
+            candidate_groups = [
+                group
+                for group in electronic_groups.values()
+                if group['model_system_ref'] is None
+                or (
+                    representative_system is not None
+                    and group['model_system_ref'] is representative_system
                 )
+            ]
+            if not candidate_groups:
+                # Nothing points at the representative system, so fall back to the
+                # single most recent system rather than mixing systems.
+                newest_group = max(
+                    electronic_groups.values(), key=lambda group: group['last_index']
+                )
+                newest_system_key = _system_key(newest_group)
+                candidate_groups = [
+                    group
+                    for group in electronic_groups.values()
+                    if _system_key(group) == newest_system_key
+                ]
 
-            selected_group = max(electronic_groups.values(), key=_group_score)
-            latest_band_gaps = selected_group['band_gaps']
-            latest_dos_sections = selected_group['dos_sections']
-            latest_dos_payload = selected_group['dos_payload']
-            latest_band_structures = selected_group['band_structures']
-            latest_greens_functions = selected_group['greens_functions']
+            # One section per method, in output order; a repeated method keeps its
+            # most recent outputs.
+            groups_by_method: dict[str | None, dict[str, Any]] = {}
+            for group in sorted(candidate_groups, key=lambda g: g['last_index']):
+                groups_by_method[self._method_label(group['model_method_ref'])] = group
+            selected_groups = list(groups_by_method.values())
 
-            if len(electronic_groups) > 1:
+            for group in selected_groups:
+                latest_band_gaps.extend(group['band_gaps'])
+                latest_dos_sections.extend(group['dos_sections'])
+                latest_band_structures.extend(group['band_structures'])
+                latest_greens_functions.extend(group['greens_functions'])
+
+            discarded_groups = len(electronic_groups) - len(selected_groups)
+            if discarded_groups:
                 self.logger.warning(
-                    'discarding alternate electronic output source groups',
-                    selected_method=getattr(
-                        getattr(selected_group['model_method_ref'], 'm_def', None),
-                        'name',
-                        None,
-                    ),
-                    discarded_groups=len(electronic_groups) - 1,
+                    'discarding electronic outputs from non-representative systems',
+                    discarded_groups=discarded_groups,
                 )
 
         if not (
@@ -1532,32 +1562,42 @@ class ResultsNormalizerBase:
 
         # Prefer run/calculation DOS compatibility paths when runschema is available,
         # so legacy GUI resolvers can follow runschema-typed references robustly.
-        if runschema and latest_dos_sections and latest_dos_payload:
+        if runschema and latest_dos_sections:
             compatibility_target = self._ensure_legacy_run_calculation(archive)
             if compatibility_target is not None:
                 calculation, run_index, calculation_index = compatibility_target
                 calculation.dos_electronic = []
-                run_total_refs: list[str] = []
-                for idx, dos_entry in enumerate(latest_dos_payload):
-                    legacy_dos = runschema.calculation.Dos()
-                    legacy_dos.energies = dos_entry['energies_points']
+                calculation_path = f'/run/{run_index}/calculation/{calculation_index}'
+                # Each method contributes its own legacy Dos sections, so indices
+                # run across the shared list instead of restarting per group.
+                for group in selected_groups:
+                    dos_sections = group['dos_sections']
+                    dos_payload = group['dos_payload']
+                    if not (dos_sections and dos_payload):
+                        continue
+                    energies_index = len(calculation.dos_electronic)
+                    run_total_refs: list[str] = []
+                    for dos_entry in dos_payload:
+                        legacy_dos = runschema.calculation.Dos()
+                        legacy_dos.energies = dos_entry['energies_points']
 
-                    legacy_total = runschema.calculation.DosValues()
-                    legacy_total.value = dos_entry['values']
-                    legacy_total.spin = int(dos_entry.get('spin_channel', 0) or 0)
-                    legacy_dos.total.append(legacy_total)
+                        legacy_total = runschema.calculation.DosValues()
+                        legacy_total.value = dos_entry['values']
+                        legacy_total.spin = int(dos_entry.get('spin_channel', 0) or 0)
+                        legacy_dos.total.append(legacy_total)
 
-                    calculation.dos_electronic.append(legacy_dos)
-                    run_total_refs.append(
-                        f'/run/{run_index}/calculation/{calculation_index}'
-                        f'/dos_electronic/{idx}/total/0'
+                        run_total_refs.append(
+                            f'{calculation_path}/dos_electronic'
+                            f'/{len(calculation.dos_electronic)}/total/0'
+                        )
+                        calculation.dos_electronic.append(legacy_dos)
+
+                    dos_sections[
+                        0
+                    ].energies = (
+                        f'{calculation_path}/dos_electronic/{energies_index}/energies'
                     )
-
-                latest_dos_sections[0].energies = (
-                    f'/run/{run_index}/calculation/{calculation_index}'
-                    '/dos_electronic/0/energies'
-                )
-                latest_dos_sections[0].total = run_total_refs
+                    dos_sections[0].total = run_total_refs
 
         # `results.properties.electronic.band_structure_electronic.segment` is a
         # reference-typed quantity. For valid references, materialize compatible

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -165,11 +165,6 @@ elements = set(ase.data.chemical_symbols)
 
 V2_COMPATIBILITY_ANNOTATION = 'nomad_topology_normalizer_v2_compatibility'
 
-# Recognize sections written by the first compatibility implementation so that
-# one normalization pass migrates them to the invisible annotation marker.
-_LEGACY_V2_COMPATIBILITY_LABEL = 'nomad-topology-normalizer:v2-compatibility'
-_LEGACY_V2_COMPATIBILITY_RUN_ID = f'{_LEGACY_V2_COMPATIBILITY_LABEL}:run'
-
 
 def valid_array(array: Any) -> bool:
     """Checks if the given variable is a non-empty array."""
@@ -650,25 +645,13 @@ class ResultsNormalizerBase:
 
     @staticmethod
     def _is_compatibility_section(section) -> bool:
-        try:
-            if V2_COMPATIBILITY_ANNOTATION in section.m_annotations:
-                return True
+        """Whether this normalizer generated the section on an earlier pass.
 
-            # Backward-compatible cleanup for archives produced by the initial
-            # visible-marker implementation. New sections never use these fields.
-            raw_id = getattr(section, 'raw_id', None)
-            if raw_id == _LEGACY_V2_COMPATIBILITY_RUN_ID:
-                return True
-            label = getattr(section, 'label', None)
-            if isinstance(label, str) and label.startswith(
-                _LEGACY_V2_COMPATIBILITY_LABEL
-            ):
-                return True
-            provenance = getattr(section, 'provenance', None)
-            provenance_label = getattr(provenance, 'label', None)
-            return isinstance(provenance_label, str) and provenance_label.startswith(
-                _LEGACY_V2_COMPATIBILITY_LABEL
-            )
+        The marker is an annotation rather than a quantity, so nothing the
+        parser owns is inspected and no user-facing field is claimed.
+        """
+        try:
+            return V2_COMPATIBILITY_ANNOTATION in section.m_annotations
         except Exception:
             return False
 
@@ -739,12 +722,8 @@ class ResultsNormalizerBase:
         )
         if run is None:
             run = runschema.run.Run()
-            self._mark_compatibility_section(run)
             archive.run.append(run)
-        else:
-            self._mark_compatibility_section(run)
-            if getattr(run, 'raw_id', None) == _LEGACY_V2_COMPATIBILITY_RUN_ID:
-                run.m_set('raw_id', None)
+        self._mark_compatibility_section(run)
 
         calculations = run.calculation
         if calculations and len(calculations) > 0:
@@ -1199,12 +1178,6 @@ class ResultsNormalizerBase:
             for compatibility_run in archive.run or []:
                 if not self._is_compatibility_section(compatibility_run):
                     continue
-                self._mark_compatibility_section(compatibility_run)
-                if (
-                    getattr(compatibility_run, 'raw_id', None)
-                    == _LEGACY_V2_COMPATIBILITY_RUN_ID
-                ):
-                    compatibility_run.m_set('raw_id', None)
                 for compatibility_calculation in compatibility_run.calculation or []:
                     self._mark_compatibility_section(compatibility_calculation)
                     compatibility_calculation.dos_electronic = []

--- a/src/nomad_topology_normalizer/normalizers/results.py
+++ b/src/nomad_topology_normalizer/normalizers/results.py
@@ -163,8 +163,12 @@ from nomad_topology_normalizer.normalizers.method import MethodNormalizer
 re_label = re.compile('^([a-zA-Z][a-zA-Z]?)[^a-zA-Z]*')
 elements = set(ase.data.chemical_symbols)
 
-V2_COMPATIBILITY_LABEL = 'nomad-topology-normalizer:v2-compatibility'
-V2_COMPATIBILITY_RUN_ID = f'{V2_COMPATIBILITY_LABEL}:run'
+V2_COMPATIBILITY_ANNOTATION = 'nomad_topology_normalizer_v2_compatibility'
+
+# Recognize sections written by the first compatibility implementation so that
+# one normalization pass migrates them to the invisible annotation marker.
+_LEGACY_V2_COMPATIBILITY_LABEL = 'nomad-topology-normalizer:v2-compatibility'
+_LEGACY_V2_COMPATIBILITY_RUN_ID = f'{_LEGACY_V2_COMPATIBILITY_LABEL}:run'
 
 
 def valid_array(array: Any) -> bool:
@@ -628,22 +632,42 @@ class ResultsNormalizerBase:
         }
 
     @staticmethod
-    def _compatibility_label(model_method_ref=None) -> str:
-        method_name = getattr(getattr(model_method_ref, 'm_def', None), 'name', None)
-        if method_name:
-            return f'{V2_COMPATIBILITY_LABEL}:{method_name}'
-        return V2_COMPATIBILITY_LABEL
+    def _method_label(model_method_ref=None) -> str | None:
+        """Return scientific method provenance without an ownership marker."""
+        return getattr(
+            getattr(model_method_ref, 'm_def', None), 'name', None
+        ) or getattr(
+            model_method_ref,
+            'name',
+            None,
+        )
+
+    @staticmethod
+    def _mark_compatibility_section(section):
+        """Mark a generated section without changing user-facing quantities."""
+        section.m_annotations[V2_COMPATIBILITY_ANNOTATION] = {'generated': True}
+        return section
 
     @staticmethod
     def _is_compatibility_section(section) -> bool:
         try:
+            if V2_COMPATIBILITY_ANNOTATION in section.m_annotations:
+                return True
+
+            # Backward-compatible cleanup for archives produced by the initial
+            # visible-marker implementation. New sections never use these fields.
+            raw_id = getattr(section, 'raw_id', None)
+            if raw_id == _LEGACY_V2_COMPATIBILITY_RUN_ID:
+                return True
             label = getattr(section, 'label', None)
-            if isinstance(label, str) and label.startswith(V2_COMPATIBILITY_LABEL):
+            if isinstance(label, str) and label.startswith(
+                _LEGACY_V2_COMPATIBILITY_LABEL
+            ):
                 return True
             provenance = getattr(section, 'provenance', None)
             provenance_label = getattr(provenance, 'label', None)
             return isinstance(provenance_label, str) and provenance_label.startswith(
-                V2_COMPATIBILITY_LABEL
+                _LEGACY_V2_COMPATIBILITY_LABEL
             )
         except Exception:
             return False
@@ -693,6 +717,10 @@ class ResultsNormalizerBase:
                 if not self._is_compatibility_section(section)
             ]
 
+        geometry_optimization = properties.geometry_optimization
+        if self._is_compatibility_section(geometry_optimization):
+            properties.geometry_optimization = None
+
     def _ensure_legacy_run_calculation(
         self, archive: EntryArchive
     ) -> tuple[Any, int, int] | None:
@@ -705,13 +733,18 @@ class ResultsNormalizerBase:
             (
                 candidate
                 for candidate in runs
-                if getattr(candidate, 'raw_id', None) == V2_COMPATIBILITY_RUN_ID
+                if self._is_compatibility_section(candidate)
             ),
             None,
         )
         if run is None:
-            run = runschema.run.Run(raw_id=V2_COMPATIBILITY_RUN_ID)
+            run = runschema.run.Run()
+            self._mark_compatibility_section(run)
             archive.run.append(run)
+        else:
+            self._mark_compatibility_section(run)
+            if getattr(run, 'raw_id', None) == _LEGACY_V2_COMPATIBILITY_RUN_ID:
+                run.m_set('raw_id', None)
 
         calculations = run.calculation
         if calculations and len(calculations) > 0:
@@ -719,6 +752,7 @@ class ResultsNormalizerBase:
         else:
             calculation = runschema.calculation.Calculation()
             run.calculation.append(calculation)
+        self._mark_compatibility_section(calculation)
 
         return (
             calculation,
@@ -1163,12 +1197,16 @@ class ResultsNormalizerBase:
         self._remove_generated_compatibility_results(properties)
         if runschema:
             for compatibility_run in archive.run or []:
+                if not self._is_compatibility_section(compatibility_run):
+                    continue
+                self._mark_compatibility_section(compatibility_run)
                 if (
                     getattr(compatibility_run, 'raw_id', None)
-                    != V2_COMPATIBILITY_RUN_ID
+                    == _LEGACY_V2_COMPATIBILITY_RUN_ID
                 ):
-                    continue
+                    compatibility_run.m_set('raw_id', None)
                 for compatibility_calculation in compatibility_run.calculation or []:
+                    self._mark_compatibility_section(compatibility_calculation)
                     compatibility_calculation.dos_electronic = []
                     compatibility_calculation.band_structure_electronic = []
 
@@ -1177,6 +1215,7 @@ class ResultsNormalizerBase:
         # no electronic/spectroscopic payload in outputs.
         geometry_optimization = self.geometry_optimization()
         if geometry_optimization is not None:
+            self._mark_compatibility_section(geometry_optimization)
             properties.geometry_optimization = geometry_optimization
 
         try:
@@ -1235,7 +1274,7 @@ class ResultsNormalizerBase:
             output_highest_occupied = None
             output_system_ref = output.model_system_ref
             output_method_ref = output.model_method_ref
-            compatibility_label = self._compatibility_label(output_method_ref)
+            method_label = self._method_label(output_method_ref)
 
             for band_structure in output.electronic_band_structures or []:
                 output_highest_occupied = band_structure.highest_occupied
@@ -1258,10 +1297,10 @@ class ResultsNormalizerBase:
                 bg_result = BandGap()
                 bg_result.value = bg.value
                 bg_result.type = bg.type
-                if runschema:
+                if runschema and method_label:
                     bg_result.provenance = (
                         runschema.calculation.ElectronicStructureProvenance(
-                            label=compatibility_label
+                            label=method_label
                         )
                     )
                 if output_highest_occupied is not None:
@@ -1286,7 +1325,7 @@ class ResultsNormalizerBase:
                 ]
                 if totals:
                     dos_result = DOSElectronic()
-                    dos_result.label = compatibility_label
+                    dos_result.label = method_label
                     dos_result.energies = dos_data_sections[0]['energies_ref']
                     dos_result.total = totals
                     dos_result.spin_polarized = len(dos_data_sections) == 2
@@ -1300,7 +1339,7 @@ class ResultsNormalizerBase:
             for band_structure in output.electronic_band_structures or []:
                 mapped_band_structure = self._map_band_structure(band_structure)
                 if mapped_band_structure:
-                    mapped_band_structure.label = compatibility_label
+                    mapped_band_structure.label = method_label
                     output_band_structures.append(mapped_band_structure)
 
             # Ensure compatibility card consumers can read a complete band-gap
@@ -1336,7 +1375,7 @@ class ResultsNormalizerBase:
 
             mapped_greens_functions = self._map_greens_functions(output)
             if mapped_greens_functions:
-                mapped_greens_functions.label = compatibility_label
+                mapped_greens_functions.label = method_label
                 output_greens_functions.append(mapped_greens_functions)
 
             if (
@@ -1375,23 +1414,26 @@ class ResultsNormalizerBase:
 
             for absorption in output.absorption_spectra or []:
                 mapped_spectrum = self._map_spectrum(absorption, 'unavailable')
-                if mapped_spectrum:
+                if mapped_spectrum and method_label:
                     mapped_spectrum.provenance = SpectraProvenance(
-                        label=compatibility_label
+                        label=method_label
                     )
+                if mapped_spectrum:
                     spectra_sections.append(mapped_spectrum)
             for xas in output.xas_spectra or []:
                 mapped_spectrum = self._map_spectrum(xas, 'XAS')
-                if mapped_spectrum:
+                if mapped_spectrum and method_label:
                     mapped_spectrum.provenance = SpectraProvenance(
-                        label=compatibility_label
+                        label=method_label
                     )
+                if mapped_spectrum:
                     spectra_sections.append(mapped_spectrum)
 
             for rg in output.radii_of_gyration or []:
                 mapped_rg = self._map_radius_of_gyration(rg)
+                if mapped_rg and method_label:
+                    mapped_rg.provenance = MDProvenance(label=method_label)
                 if mapped_rg:
-                    mapped_rg.provenance = MDProvenance(label=compatibility_label)
                     rg_sections.append(mapped_rg)
 
             point_time = getattr(output, 'time', None)
@@ -1562,14 +1604,18 @@ class ResultsNormalizerBase:
                 electronic = properties.m_create(ElectronicProperties)
 
             for band_gap in latest_band_gaps:
+                self._mark_compatibility_section(band_gap)
                 electronic.m_add_sub_section(ElectronicProperties.band_gap, band_gap)
             for dos in latest_dos_sections:
+                self._mark_compatibility_section(dos)
                 electronic.m_add_sub_section(ElectronicProperties.dos_electronic, dos)
             for band_structure in latest_band_structures:
+                self._mark_compatibility_section(band_structure)
                 electronic.m_add_sub_section(
                     ElectronicProperties.band_structure_electronic, band_structure
                 )
             for greens in latest_greens_functions:
+                self._mark_compatibility_section(greens)
                 electronic.m_add_sub_section(
                     ElectronicProperties.greens_functions_electronic, greens
                 )
@@ -1579,6 +1625,7 @@ class ResultsNormalizerBase:
             if spectroscopic is None:
                 spectroscopic = properties.m_create(SpectroscopicProperties)
             for spectrum in spectra_sections:
+                self._mark_compatibility_section(spectrum)
                 spectroscopic.m_add_sub_section(
                     SpectroscopicProperties.spectra, spectrum
                 )
@@ -1588,6 +1635,7 @@ class ResultsNormalizerBase:
             if structural is None:
                 structural = properties.m_create(StructuralProperties)
             for rg in rg_sections:
+                self._mark_compatibility_section(rg)
                 structural.m_add_sub_section(
                     StructuralProperties.radius_of_gyration, rg
                 )
@@ -1596,9 +1644,8 @@ class ResultsNormalizerBase:
             thermodynamic = properties.thermodynamic
             if thermodynamic is None:
                 thermodynamic = properties.m_create(ThermodynamicProperties)
-            trajectory = Trajectory(
-                provenance=MDProvenance(label=V2_COMPATIBILITY_LABEL)
-            )
+            trajectory = Trajectory()
+            self._mark_compatibility_section(trajectory)
             available_properties: list[str] = []
             if temperature_series:
                 trajectory.temperature = TemperatureDynamic(

--- a/src/nomad_topology_normalizer/normalizers/symmetry_adapter.py
+++ b/src/nomad_topology_normalizer/normalizers/symmetry_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from ase.data import chemical_symbols
-from nomad.datamodel.results import WyckoffSet
+from nomad.datamodel.results import WyckoffSet, bravais_lattices, crystal_systems
 
 # TODO(migration): Keep adapter local to topology-normalizer during v2 migration.
 # TODO(migration): Re-evaluate elevation only after nomad-simulations/nomad-FAIR
@@ -38,6 +38,31 @@ def is_symmetry_data_minimally_complete(symmetry_data: dict[str, Any]) -> bool:
         and symmetry_data.get('space_group_symbol')
         and symmetry_data.get('point_group')
     )
+
+
+def _crystal_system_from_lattice_type(lattice_type: Any) -> str | None:
+    """Map a v2 `lattice_type` onto the legacy `crystal_system` enum.
+
+    `GlobalCrystalSymmetry` has no `crystal_system` quantity; it carries the
+    crystal family in Pearson-style `'<code> - <name>'` form (e.g. `'c - cubic'`).
+    Only the seven 3D names have a legacy-equivalent target, so the 2D/1D lattice
+    types (`'mp - oblique'`, `'hp - hexagonal 2D'`, ...) stay unmapped.
+    """
+    if not isinstance(lattice_type, str):
+        return None
+    crystal_system = lattice_type.split(' - ')[-1].strip().lower()
+    return crystal_system if crystal_system in crystal_systems else None
+
+
+def _legacy_bravais_lattice(bravais_lattice: Any) -> str | None:
+    """Keep only Pearson symbols that the legacy `bravais_lattice` enum accepts.
+
+    The v2 `bravais_lattice` property also reconstructs 2D/1D symbols such as
+    `'mpp'` or `'ocp'`, which are not enum members and would raise on assignment.
+    """
+    if not isinstance(bravais_lattice, str):
+        return None
+    return bravais_lattice if bravais_lattice in bravais_lattices else None
 
 
 def from_legacy_repr_symmetry(repr_symmetry: Any) -> dict[str, Any]:
@@ -88,8 +113,11 @@ def from_model_system(model_system: Any) -> dict[str, Any]:
     symmetry_data.update(
         hall_number=getattr(symmetry, 'hall_number', None),
         hall_symbol=getattr(symmetry, 'hall_symbol', None),
-        bravais_lattice=getattr(symmetry, 'bravais_lattice', None),
-        crystal_system=getattr(symmetry, 'crystal_system', None),
+        bravais_lattice=_legacy_bravais_lattice(
+            getattr(symmetry, 'bravais_lattice', None)
+        ),
+        crystal_system=getattr(symmetry, 'crystal_system', None)
+        or _crystal_system_from_lattice_type(getattr(symmetry, 'lattice_type', None)),
         space_group_number=getattr(symmetry, 'space_group_number', None),
         space_group_symbol=getattr(symmetry, 'space_group_symbol', None),
         point_group=getattr(symmetry, 'point_group_symbol', None),
@@ -156,10 +184,7 @@ def wyckoff_sets_from_model_system(model_system: Any) -> list[WyckoffSet] | None
 
     try:
         if not labels or not (
-            len(labels)
-            == len(letters)
-            == len(equivalent_atoms)
-            == len(multiplicities)
+            len(labels) == len(letters) == len(equivalent_atoms) == len(multiplicities)
         ):
             return None
     except TypeError:
@@ -214,21 +239,31 @@ def apply_symmetry_data_to_results_symmetry(
     if target_symmetry is None or symmetry_data is None:
         return
 
+    # `results.material.symmetry` (Symmetry) and topology `System.symmetry`
+    # (SymmetryNew) name the AFLOW prototype id differently, so each source field
+    # lists every legacy-equivalent target name and the first declared one wins.
+    # Without this the prototype id is silently dropped on topology nodes.
     field_map = {
-        'hall_number': 'hall_number',
-        'hall_symbol': 'hall_symbol',
-        'bravais_lattice': 'bravais_lattice',
-        'crystal_system': 'crystal_system',
-        'space_group_number': 'space_group_number',
-        'space_group_symbol': 'space_group_symbol',
-        'point_group': 'point_group',
-        'strukturbericht_designation': 'strukturbericht_designation',
-        'prototype_formula': 'prototype_formula',
-        'prototype_aflow_id': 'prototype_aflow_id',
-        'origin_shift': 'origin_shift',
-        'transformation_matrix': 'transformation_matrix',
+        'hall_number': ('hall_number',),
+        'hall_symbol': ('hall_symbol',),
+        'bravais_lattice': ('bravais_lattice',),
+        'crystal_system': ('crystal_system',),
+        'space_group_number': ('space_group_number',),
+        'space_group_symbol': ('space_group_symbol',),
+        'point_group': ('point_group',),
+        'strukturbericht_designation': ('strukturbericht_designation',),
+        # `SymmetryNew.prototype_name` carries the structure name (e.g. 'wurtzite'),
+        # not the prototype formula, so it is deliberately not a target here.
+        'prototype_formula': ('prototype_formula',),
+        'prototype_aflow_id': ('prototype_aflow_id', 'prototype_label_aflow'),
+        'origin_shift': ('origin_shift',),
+        'transformation_matrix': ('transformation_matrix',),
     }
-    for source_name, target_name in field_map.items():
+    for source_name, target_names in field_map.items():
         value = symmetry_data.get(source_name)
-        if value is not None and hasattr(target_symmetry, target_name):
-            setattr(target_symmetry, target_name, value)
+        if value is None:
+            continue
+        for target_name in target_names:
+            if hasattr(target_symmetry, target_name):
+                setattr(target_symmetry, target_name, value)
+                break

--- a/src/nomad_topology_normalizer/normalizers/symmetry_adapter.py
+++ b/src/nomad_topology_normalizer/normalizers/symmetry_adapter.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from ase.data import chemical_symbols
+from nomad.datamodel.results import WyckoffSet
+
 # TODO(migration): Keep adapter local to topology-normalizer during v2 migration.
 # TODO(migration): Re-evaluate elevation only after nomad-simulations/nomad-FAIR
 # symmetry field stability is confirmed and cross-plugin parity fixtures exist.
@@ -102,6 +105,106 @@ def from_model_system(model_system: Any) -> dict[str, Any]:
         site_multiplicities=getattr(local_symmetry, 'site_multiplicities', None),
     )
     return symmetry_data
+
+
+def find_model_system_representation(model_system: Any, cell_type: str) -> Any | None:
+    """Return an existing analyzed representation for the requested cell type."""
+    if model_system is None:
+        return None
+    requested = cell_type.lower()
+    for representation in getattr(model_system, 'representations', None) or []:
+        representation_type = getattr(representation, 'crystal_cell_type', None)
+        representation_name = getattr(representation, 'name', None)
+        if any(
+            isinstance(value, str) and value.lower() == requested
+            for value in (representation_type, representation_name)
+        ):
+            return representation
+    return None
+
+
+def wyckoff_sets_from_model_system(model_system: Any) -> list[WyckoffSet] | None:
+    """Build legacy material-id inputs from normalized v2 local symmetry.
+
+    ``site_multiplicities`` already contains the conventional-cell orbit size.
+    The returned indices are therefore count carriers for the unchanged legacy
+    ``material_id_bulk`` hashing function; no crystallographic analysis is repeated.
+    """
+    if model_system is None:
+        return None
+
+    local_symmetry = getattr(model_system, 'local_symmetry', None)
+    letters = getattr(local_symmetry, 'wyckoff_letters', None)
+    equivalent_atoms = getattr(local_symmetry, 'equivalent_atoms', None)
+    multiplicities = getattr(local_symmetry, 'site_multiplicities', None)
+    if letters is None or equivalent_atoms is None or multiplicities is None:
+        return None
+
+    try:
+        labels = list(model_system.get_symbols())
+    except Exception:
+        labels = []
+        for particle_state in getattr(model_system, 'particle_states', None) or []:
+            label = getattr(particle_state, 'chemical_symbol', None)
+            if label is None:
+                atomic_number = getattr(particle_state, 'atomic_number', None)
+                try:
+                    label = chemical_symbols[int(atomic_number)]
+                except Exception:
+                    return None
+            labels.append(label)
+
+    try:
+        if not labels or not (
+            len(labels)
+            == len(letters)
+            == len(equivalent_atoms)
+            == len(multiplicities)
+        ):
+            return None
+    except TypeError:
+        return None
+
+    grouped_indices: dict[int, list[int]] = {}
+    for index, equivalent_index in enumerate(equivalent_atoms):
+        grouped_indices.setdefault(int(equivalent_index), []).append(index)
+
+    wyckoff_sets: list[WyckoffSet] = []
+    for indices in grouped_indices.values():
+        elements = {str(labels[index]) for index in indices}
+        group_letters = {str(letters[index]) for index in indices}
+        group_multiplicities = {int(multiplicities[index]) for index in indices}
+        if (
+            len(elements) != 1
+            or len(group_letters) != 1
+            or len(group_multiplicities) != 1
+        ):
+            return None
+
+        multiplicity = group_multiplicities.pop()
+        if multiplicity <= 0:
+            return None
+        wyckoff_sets.append(
+            WyckoffSet(
+                element=elements.pop(),
+                wyckoff_letter=group_letters.pop(),
+                indices=list(range(multiplicity)),
+            )
+        )
+
+    return wyckoff_sets or None
+
+
+def has_complete_model_system_symmetry(model_system: Any) -> bool:
+    """Whether v2 carries every input needed for bulk results and material ID."""
+    symmetry_data = from_model_system(model_system)
+    conventional = find_model_system_representation(model_system, 'conventional')
+    return bool(
+        is_symmetry_data_minimally_complete(symmetry_data)
+        and wyckoff_sets_from_model_system(model_system)
+        and conventional is not None
+        and getattr(conventional, 'lattice_vectors', None) is not None
+    )
 
 
 def apply_symmetry_data_to_results_symmetry(

--- a/src/nomad_topology_normalizer/normalizers/topology.py
+++ b/src/nomad_topology_normalizer/normalizers/topology.py
@@ -415,10 +415,6 @@ class TopologyNormalizer(Normalizer):
             )
         return symmetry_data
 
-    def _has_complete_model_system_symmetry(self) -> bool:
-        """True when v2 ModelSystem symmetry is complete without legacy fallback."""
-        return is_symmetry_data_minimally_complete(from_model_system(self.repr_system))
-
     @staticmethod
     def _symmetry_from_data(symmetry_data: dict[str, object]) -> Symmetry | None:
         if not any(value is not None for value in symmetry_data.values()):
@@ -437,6 +433,7 @@ class TopologyNormalizer(Normalizer):
         self.repr_system = None
         self.repr_symmetry = None
         self.conv_atoms = None
+        self._matid_symmetry_analyzer = None
         self.masses = None
 
         # Get representative system from data
@@ -502,12 +499,7 @@ class TopologyNormalizer(Normalizer):
         topology = self.topology_calculation()
 
         # Second: create topology with MatID
-        skip_matid_bulk = bool(
-            material
-            and material.structural_type == 'bulk'
-            and self._has_complete_model_system_symmetry()
-        )
-        if topology is None and not skip_matid_bulk:
+        if topology is None:
             with utils.timer(self.logger, 'calculating topology with matid'):
                 topology = self.topology_matid(material)
 
@@ -701,6 +693,25 @@ class TopologyNormalizer(Normalizer):
         if not atoms or len(atoms) == 0:
             return None
 
+        if material.structural_type == 'bulk' and self.conv_atoms is None:
+            try:
+                symmetry_system = atoms.copy()
+                symmetry_system.set_pbc(True)
+                self._matid_symmetry_analyzer = SymmetryAnalyzer(
+                    symmetry_system,
+                    config.normalize.symmetry_tolerance,
+                    config.normalize.flat_dim_threshold,
+                )
+                self.conv_atoms = (
+                    self._matid_symmetry_analyzer.get_conventional_system()
+                )
+                self.conv_atoms.set_pbc(True)
+            except Exception as error:
+                self.logger.warning(
+                    'could not construct MatID inputs for v2 bulk system',
+                    exc_info=error,
+                )
+
         # Create topology for the original system
         topology: dict[str, System] = {}
         particles = self.repr_system.particle_states
@@ -870,6 +881,8 @@ class TopologyNormalizer(Normalizer):
         m_cache = getattr(self.repr_symmetry, 'm_cache', None)
         if m_cache is not None and hasattr(m_cache, 'get'):
             symmetry_analyzer = m_cache.get('symmetry_analyzer')
+        if symmetry_analyzer is None:
+            symmetry_analyzer = self._matid_symmetry_analyzer
 
         symmetry_data = self._resolved_symmetry_data()
         conv_system.symmetry = self._symmetry_from_data(symmetry_data)
@@ -885,6 +898,8 @@ class TopologyNormalizer(Normalizer):
                 symmetry_analyzer.get_space_group_number(),
                 symmetry_analyzer.get_wyckoff_sets_conventional(),
             )
+            if material is not None:
+                material.material_id = conv_system.material_id
         add_system(conv_system, topology, subsystem)
         add_system_info_2(conv_system, topology, parent_system=self.repr_system)
 

--- a/src/nomad_topology_normalizer/normalizers/topology.py
+++ b/src/nomad_topology_normalizer/normalizers/topology.py
@@ -12,10 +12,12 @@ Topology Creation Strategy (Waterfall)
 1. **topology_calculation()** - Extract from parser-defined sub_systems
    └─ Uses data.model_system[].sub_systems if available
 
-2. **topology_matid()** - Algorithmic detection using MatID
+2. **topology_v2_symmetry()** - Consume analyzed v2 symmetry/representations
+
+3. **topology_matid()** - Algorithmic fallback using MatID
    └─ Symmetry analysis and clustering for automatic topology detection
 
-3. **topology_data()** - Fallback for SystemV2 entries
+4. **topology_data()** - Fallback for SystemV2 entries
    └─ Direct conversion from SystemV2 structure
 
 Note: Schema version detection and routing logic is in ResultsNormalizer.
@@ -77,9 +79,12 @@ from nomad_topology_normalizer.normalizers.material import MaterialNormalizer
 from nomad_topology_normalizer.normalizers.normalizer import Normalizer
 from nomad_topology_normalizer.normalizers.symmetry_adapter import (
     apply_symmetry_data_to_results_symmetry,
+    find_model_system_representation,
     from_legacy_repr_symmetry,
     from_model_system,
+    has_complete_model_system_symmetry,
     is_symmetry_data_minimally_complete,
+    wyckoff_sets_from_model_system,
 )
 
 conventional_description: str = (
@@ -498,12 +503,17 @@ class TopologyNormalizer(Normalizer):
         # First: topology from data schema calculation (v2)
         topology = self.topology_calculation()
 
-        # Second: create topology with MatID
+        # Second: consume symmetry and conventional-cell data already normalized
+        # by nomad-simulations. This avoids repeating MatID symmetry analysis.
+        if topology is None:
+            topology = self.topology_v2_symmetry(material)
+
+        # Third: use MatID only when required v2 inputs are missing/incomplete.
         if topology is None:
             with utils.timer(self.logger, 'calculating topology with matid'):
                 topology = self.topology_matid(material)
 
-        # Third: fallback to topology_data for SystemV2 entries
+        # Fourth: fallback to topology_data for SystemV2 entries
         if topology is None:
             if system_v2 is not None:
                 topology = self.topology_data(system_v2)
@@ -678,6 +688,76 @@ class TopologyNormalizer(Normalizer):
                 result = list(topology.values())
 
         return result
+
+    def topology_v2_symmetry(self, material: Material) -> list[System] | None:
+        """Build bulk topology from existing v2 symmetry and representations."""
+        if getattr(self.repr_system, 'type', None) != 'bulk':
+            return None
+        if not has_complete_model_system_symmetry(self.repr_system):
+            return None
+
+        conventional = find_model_system_representation(
+            self.repr_system, 'conventional'
+        )
+        symmetry_data = from_model_system(self.repr_system)
+        wyckoff_sets = wyckoff_sets_from_model_system(self.repr_system)
+        material_id = material.material_id or material_id_bulk(
+            symmetry_data['space_group_number'], wyckoff_sets
+        )
+        if conventional is None or material_id is None:
+            return None
+
+        try:
+            lattice_vectors = conventional.lattice_vectors.to('angstrom').magnitude
+            conventional_symbols = [
+                wyckoff_set.element
+                for wyckoff_set in wyckoff_sets
+                for _ in wyckoff_set.indices
+            ]
+            # This transient ASE object is used only by the existing Cell adapter
+            # to calculate lattice parameters and densities. No positions are
+            # published because v2 representations do not currently carry them.
+            cell_atoms = Atoms(
+                symbols=conventional_symbols,
+                cell=np.asarray(lattice_vectors),
+                pbc=True,
+            )
+        except Exception:
+            return None
+
+        topology: dict[str, System] = {}
+        particles = getattr(self.repr_system, 'particle_states', None)
+        original = get_topology_original(particles, self.entry_archive)
+        add_system(original, topology)
+        add_system_info_2(original, topology, parent_system=self.repr_system)
+
+        subsystem = System(
+            method='parser',
+            label='subsystem',
+            dimensionality='3D',
+            structural_type='bulk',
+            description=subsystem_description,
+            system_relation=Relation(type='subsystem'),
+            indices=[list(range(original.n_atoms))],
+        )
+        add_system(subsystem, topology, original)
+        add_system_info_2(subsystem, topology, parent_system=self.repr_system)
+
+        conventional_system = System(
+            method='parser',
+            label='conventional cell',
+            dimensionality='3D',
+            structural_type='bulk',
+            description=conventional_description,
+            system_relation=Relation(type='conventional_cell'),
+            n_atoms=sum(len(wyckoff_set.indices) for wyckoff_set in wyckoff_sets),
+            material_id=material_id,
+            symmetry=self._symmetry_from_data(symmetry_data),
+            cell=cell_from_ase_atoms(cell_atoms),
+        )
+        add_system(conventional_system, topology, subsystem)
+        material.material_id = material_id
+        return list(topology.values())
 
     def topology_matid(self, material: Material) -> list[SystemV2] | None:  # noqa: PLR0912
         """

--- a/src/nomad_topology_normalizer/normalizers/topology.py
+++ b/src/nomad_topology_normalizer/normalizers/topology.py
@@ -689,6 +689,42 @@ class TopologyNormalizer(Normalizer):
 
         return result
 
+    def _conventional_atoms_for_viewer(self) -> Atoms | None:
+        """Conventional-cell geometry for the GUI structure viewer.
+
+        The v2 conventional `Representation` carries `lattice_vectors` but neither
+        positions nor per-site species, so the viewer payload cannot be built from
+        v2 data alone. This recovers geometry only - symmetry and `material_id`
+        still come from the values `nomad-simulations` already normalized and are
+        never recomputed here.
+
+        TODO(migration): drop this once `resolve_analyzed_cell` publishes the
+        conventional cell's fractional coordinates and atomic numbers.
+        """
+        try:
+            atoms = self.repr_system.to_ase_atoms()
+        except Exception:
+            return None
+        if not atoms or len(atoms) == 0:
+            return None
+
+        try:
+            analyzed_system = atoms.copy()
+            analyzed_system.set_pbc(True)
+            conventional_atoms = SymmetryAnalyzer(
+                analyzed_system,
+                config.normalize.symmetry_tolerance,
+                config.normalize.flat_dim_threshold,
+            ).get_conventional_system()
+            conventional_atoms.set_pbc(True)
+            return conventional_atoms
+        except Exception as error:
+            self.logger.warning(
+                'could not build conventional cell geometry for the structure viewer',
+                exc_info=error,
+            )
+            return None
+
     def topology_v2_symmetry(self, material: Material) -> list[System] | None:
         """Build bulk topology from existing v2 symmetry and representations."""
         if getattr(self.repr_system, 'type', None) != 'bulk':
@@ -714,9 +750,8 @@ class TopologyNormalizer(Normalizer):
                 for wyckoff_set in wyckoff_sets
                 for _ in wyckoff_set.indices
             ]
-            # This transient ASE object is used only by the existing Cell adapter
-            # to calculate lattice parameters and densities. No positions are
-            # published because v2 representations do not currently carry them.
+            # Fallback cell carrier: enough for the Cell adapter to derive lattice
+            # parameters and densities, but it has no meaningful positions.
             cell_atoms = Atoms(
                 symbols=conventional_symbols,
                 cell=np.asarray(lattice_vectors),
@@ -724,6 +759,19 @@ class TopologyNormalizer(Normalizer):
             )
         except Exception:
             return None
+
+        n_conventional_atoms = len(conventional_symbols)
+        viewer_atoms = self._conventional_atoms_for_viewer()
+        if viewer_atoms is not None and len(viewer_atoms) != n_conventional_atoms:
+            # The two counts derive from the same space group, so a mismatch means
+            # the v2 Wyckoff payload and the geometry disagree. Trust neither for
+            # the viewer rather than publishing a cell that contradicts material_id.
+            self.logger.warning(
+                'conventional cell atom count disagrees with v2 Wyckoff multiplicities',
+                n_wyckoff_atoms=n_conventional_atoms,
+                n_geometry_atoms=len(viewer_atoms),
+            )
+            viewer_atoms = None
 
         topology: dict[str, System] = {}
         particles = getattr(self.repr_system, 'particle_states', None)
@@ -750,11 +798,14 @@ class TopologyNormalizer(Normalizer):
             structural_type='bulk',
             description=conventional_description,
             system_relation=Relation(type='conventional_cell'),
-            n_atoms=sum(len(wyckoff_set.indices) for wyckoff_set in wyckoff_sets),
+            n_atoms=n_conventional_atoms,
             material_id=material_id,
             symmetry=self._symmetry_from_data(symmetry_data),
-            cell=cell_from_ase_atoms(cell_atoms),
+            cell=cell_from_ase_atoms(viewer_atoms or cell_atoms),
         )
+        if viewer_atoms is not None:
+            # The molecular visualizer resolves this runschema-typed field.
+            conventional_system.atoms = nomad_atoms_from_ase_atoms(viewer_atoms)
         add_system(conventional_system, topology, subsystem)
         material.material_id = material_id
         return list(topology.values())

--- a/tests/normalizers/test_material_normalizer.py
+++ b/tests/normalizers/test_material_normalizer.py
@@ -121,6 +121,29 @@ class TestMaterialNormalizer:
         assert 'Na' in symbols
         assert 'Cl' in symbols
 
+    @pytest.mark.parametrize('system_type', ['molecule', 'cluster'])
+    def test_molecule_and_cluster_use_legacy_combined_structural_type(
+        self, system_type
+    ):
+        archive = EntryArchive(metadata=EntryMetadata(), results=Results())
+        system = create_test_system()
+        system.type = system_type
+        archive.data = Simulation(model_system=[system])
+
+        material = MaterialNormalizer(
+            archive,
+            system,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            LOGGER,
+        ).material(populate_topology=False)
+
+        assert material.structural_type == 'molecule / cluster'
+
     def test_dimensionality_from_pbc(self):
         """Test that dimensionality is correctly determined from PBC."""
         archive = EntryArchive(metadata=EntryMetadata())

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -1475,6 +1475,8 @@ def test_data_schema_preserves_legacy_calculation_and_result_sections():
     assert archive.run[0] is legacy_run
     assert legacy_calculation.dos_electronic[0] is legacy_dos
     assert legacy_calculation.band_structure_electronic[0] is legacy_band_structure
+    # The generated run is identified by annotation alone; no user-facing
+    # quantity is claimed to mark it.
     assert archive.run[1].raw_id is None
     assert V2_COMPATIBILITY_ANNOTATION in archive.run[1].m_annotations
     assert any(section.label == 'parser-owned' for section in electronic.dos_electronic)
@@ -1499,7 +1501,6 @@ def test_data_schema_preserves_legacy_calculation_and_result_sections():
     )
     assert archive.m_resolve(generated_dos['energies']) is not None
     assert all(archive.m_resolve(ref) is not None for ref in generated_dos['total'])
-    assert 'nomad-topology-normalizer:v2-compatibility' not in repr(serialized)
 
 
 def test_data_schema_output_mapping_is_idempotent(archive_with_data_schema):

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -74,7 +74,7 @@ from nomad_simulations.schema_packages.workflow.geometry_optimization import (
 )
 
 from nomad_topology_normalizer.normalizers.results import (
-    V2_COMPATIBILITY_RUN_ID,
+    V2_COMPATIBILITY_ANNOTATION,
 )
 from nomad_topology_normalizer.normalizers.results import (
     ResultsNormalizerBase as ResultsNormalizer,
@@ -1320,7 +1320,7 @@ def test_data_schema_does_not_merge_different_method_outputs(
 
     electronic = archive_with_data_schema.results.properties.electronic
     assert electronic.band_structure_electronic
-    assert electronic.band_structure_electronic[0].label.endswith(':GW')
+    assert electronic.band_structure_electronic[0].label == 'GW'
     assert not electronic.dos_electronic
 
 
@@ -1383,7 +1383,8 @@ def test_data_schema_preserves_legacy_calculation_and_result_sections():
     assert archive.run[0] is legacy_run
     assert legacy_calculation.dos_electronic[0] is legacy_dos
     assert legacy_calculation.band_structure_electronic[0] is legacy_band_structure
-    assert archive.run[1].raw_id == V2_COMPATIBILITY_RUN_ID
+    assert archive.run[1].raw_id is None
+    assert V2_COMPATIBILITY_ANNOTATION in archive.run[1].m_annotations
     assert any(section.label == 'parser-owned' for section in electronic.dos_electronic)
     assert any(
         section.label == 'parser-owned'
@@ -1397,14 +1398,16 @@ def test_data_schema_preserves_legacy_calculation_and_result_sections():
         for section in serialized['results']['properties']['electronic'][
             'dos_electronic'
         ]
-        if section.get('label', '').startswith('nomad-topology-normalizer:')
+        if V2_COMPATIBILITY_ANNOTATION in section.get('m_annotations', {})
     )
+    assert generated_dos.get('label') is None
     assert generated_dos['energies'].startswith('/run/1/calculation/0/')
     assert all(
         ref.startswith('/run/1/calculation/0/') for ref in generated_dos['total']
     )
     assert archive.m_resolve(generated_dos['energies']) is not None
     assert all(archive.m_resolve(ref) is not None for ref in generated_dos['total'])
+    assert 'nomad-topology-normalizer:v2-compatibility' not in repr(serialized)
 
 
 def test_data_schema_output_mapping_is_idempotent(archive_with_data_schema):
@@ -1425,6 +1428,17 @@ def test_data_schema_output_mapping_is_idempotent(archive_with_data_schema):
         len(properties.thermodynamic.trajectory),
     )
     first_time = properties.thermodynamic.trajectory[0].temperature.time.copy()
+
+    assert V2_COMPATIBILITY_ANNOTATION in (
+        properties.spectroscopic.spectra[0].m_annotations
+    )
+    assert V2_COMPATIBILITY_ANNOTATION in (
+        properties.structural.radius_of_gyration[0].m_annotations
+    )
+    assert V2_COMPATIBILITY_ANNOTATION in (
+        properties.thermodynamic.trajectory[0].m_annotations
+    )
+    assert properties.thermodynamic.trajectory[0].provenance is None
 
     normalizer.normalize(archive_with_data_schema, LOGGER)
 

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -55,6 +55,7 @@ from nomad_simulations.schema_packages.properties import (
 from nomad_simulations.schema_packages.variables import (
     Energy2,
     Frequency,
+    ImaginaryTime,
     KLinePath,
     MatsubaraFrequency,
 )
@@ -1459,6 +1460,34 @@ def test_greens_mapping_does_not_create_axis_only_result():
     normalizer.logger = LOGGER
 
     assert normalizer._map_greens_functions(output) is None
+
+
+def test_greens_mapping_recovers_from_incompatible_payload_shape(caplog):
+    if 'tau' not in GreensFunctionsElectronic.m_def.all_quantities:
+        pytest.skip('legacy Green functions fields unavailable')
+
+    greens = SimpleNamespace(
+        imaginary_time=ImaginaryTime(points=np.array([0.0, 1.0]) * ureg.s),
+        matsubara_frequency=None,
+        real_frequency=None,
+        value=np.array([1.0, 2.0]) / ureg.eV,
+    )
+    output = SimpleNamespace(
+        electronic_greens_functions=[greens],
+        electronic_self_energies=[],
+        hybridization_functions=[],
+        quasiparticle_weights=[],
+        chemical_potentials=[],
+    )
+    normalizer = ResultsNormalizer()
+    normalizer.logger = LOGGER
+
+    caplog.clear()
+    assert normalizer._map_greens_functions(output) is None
+    assert any(
+        'skipping incompatible greens axis/payload pair' in record.message
+        for record in caplog.records
+    )
 
 
 def test_data_schema_logs_unmapped_output_groups(archive_with_data_schema, caplog):

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -7,6 +7,7 @@ from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel.results import (
     DOSElectronic,
     ElectronicProperties,
+    GreensFunctionsElectronic,
     Properties,
     Results,
 )
@@ -24,7 +25,11 @@ from nomad_simulations.schema_packages.model_method import (
     Wannier,
 )
 from nomad_simulations.schema_packages.model_system import ModelSystem
-from nomad_simulations.schema_packages.numerical_settings import KSpace, Smearing
+from nomad_simulations.schema_packages.numerical_settings import (
+    KSpace,
+    SelfConsistency,
+    Smearing,
+)
 from nomad_simulations.schema_packages.outputs import Outputs
 from nomad_simulations.schema_packages.properties import (
     AbsorptionSpectrum,
@@ -494,6 +499,21 @@ def test_data_schema_maps_dft_spin_and_jacobs_ladder():
     assert archive.results.method.simulation.dft.xc_functional_type == 'GGA'
 
 
+def test_data_schema_maps_flexible_unit_scf_threshold(archive_with_data_schema):
+    """Current SelfConsistency quantities should map without a legacy unit field."""
+    simulation = archive_with_data_schema.data
+    simulation.program = Program(name='VASP')
+    dft = DFT()
+    dft.numerical_settings.append(SelfConsistency(threshold_change=1.0e-5 * ureg.eV))
+    simulation.model_method.append(dft)
+
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    simulation_results = archive_with_data_schema.results.method.simulation
+    threshold = simulation_results.dft.scf_threshold_energy_change
+    assert threshold.to('eV').magnitude == pytest.approx(1.0e-5)
+
+
 def test_data_schema_maps_outputs_electronic_properties():
     """v2 outputs should map electronic properties into results."""
     archive = EntryArchive(metadata=EntryMetadata())
@@ -531,11 +551,16 @@ def test_data_schema_maps_outputs_electronic_properties():
     band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
     band_structure.k_path = _kline_path()
     output.electronic_band_structures.append(band_structure)
-    greens_function = ElectronicGreensFunction(value=(1.0 + 0.0j) / ureg.eV)
-    greens_function.matsubara_frequency = MatsubaraFrequency(
-        points=np.array([0.1j, 0.2j]) * ureg.eV
-    )
-    output.electronic_greens_functions.append(greens_function)
+    greens_value_type = ElectronicGreensFunction.m_def.all_quantities['value'].type
+    if (
+        'tau' in GreensFunctionsElectronic.m_def.all_quantities
+        and greens_value_type.__class__.__name__ != 'HDF5Dataset'
+    ):
+        greens_function = ElectronicGreensFunction(value=(1.0 + 0.0j) / ureg.eV)
+        greens_function.matsubara_frequency = MatsubaraFrequency(
+            points=np.array([0.1j, 0.2j]) * ureg.eV
+        )
+        output.electronic_greens_functions.append(greens_function)
     absorption = AbsorptionSpectrum(value=np.array([0.5, 0.6]) / ureg.eV)
     absorption.energies = Energy2(points=np.array([0.0, 1.0]) * ureg.eV)
     output.absorption_spectra.append(absorption)

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -1,10 +1,14 @@
 """Tests for ResultsNormalizer schema detection and routing logic."""
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 from nomad.datamodel import EntryArchive, EntryMetadata
 from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel.results import (
+    BandGap,
+    BandStructureElectronic,
     DOSElectronic,
     ElectronicProperties,
     GreensFunctionsElectronic,
@@ -30,7 +34,7 @@ from nomad_simulations.schema_packages.numerical_settings import (
     SelfConsistency,
     Smearing,
 )
-from nomad_simulations.schema_packages.outputs import Outputs
+from nomad_simulations.schema_packages.outputs import Outputs, TrajectoryOutputs
 from nomad_simulations.schema_packages.properties import (
     AbsorptionSpectrum,
     ElectronicBandGap,
@@ -50,6 +54,7 @@ from nomad_simulations.schema_packages.properties import (
 )
 from nomad_simulations.schema_packages.variables import (
     Energy2,
+    Frequency,
     KLinePath,
     MatsubaraFrequency,
 )
@@ -68,11 +73,15 @@ from nomad_simulations.schema_packages.workflow.geometry_optimization import (
 )
 
 from nomad_topology_normalizer.normalizers.results import (
+    V2_COMPATIBILITY_RUN_ID,
+)
+from nomad_topology_normalizer.normalizers.results import (
     ResultsNormalizerBase as ResultsNormalizer,
 )
 
 try:
     import runschema.calculation  # noqa: F401
+    import runschema.run  # noqa: F401
 
     HAS_RUNSCHEMA = True
 except Exception:
@@ -541,14 +550,14 @@ def test_data_schema_maps_outputs_electronic_properties():
     model_system.periodic_boundary_conditions = [True, True, True]
     simulation.model_system.append(model_system)
 
-    output = Outputs()
+    output = TrajectoryOutputs(time=0.0 * ureg.ps)
     output.electronic_band_gaps.append(ElectronicBandGap(value=1.5 * ureg.eV))
     dos = ElectronicDensityOfStates(
         value=np.array([0.1, 0.2, 0.3]) / ureg.eV, spin_channel=0
     )
     dos.energies = Energy2(points=np.array([-1.0, 0.0, 1.0]) * ureg.eV)
     output.electronic_dos.append(dos)
-    band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     band_structure.k_path = _kline_path()
     output.electronic_band_structures.append(band_structure)
     greens_value_type = ElectronicGreensFunction.m_def.all_quantities['value'].type
@@ -569,7 +578,7 @@ def test_data_schema_maps_outputs_electronic_properties():
     output.potential_energies.append(SimPotentialEnergy(value=-5.0 * ureg.eV))
     simulation.outputs.append(output)
 
-    output_2 = Outputs()
+    output_2 = TrajectoryOutputs(time=1.0 * ureg.ps)
     output_2.temperatures.append(SimTemperature(value=320 * ureg.kelvin))
     output_2.potential_energies.append(SimPotentialEnergy(value=-4.8 * ureg.eV))
     simulation.outputs.append(output_2)
@@ -630,14 +639,14 @@ def test_data_schema_uses_latest_output_for_electronic_properties():
 
     output_1 = Outputs()
     output_1.electronic_band_gaps.append(ElectronicBandGap(value=1.5 * ureg.eV))
-    band_structure_1 = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure_1 = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     band_structure_1.k_path = _kline_path()
     output_1.electronic_band_structures.append(band_structure_1)
     simulation.outputs.append(output_1)
 
     output_2 = Outputs()
     output_2.electronic_band_gaps.append(ElectronicBandGap(value=2.5 * ureg.eV))
-    band_structure_2 = ElectronicBandStructure(value=np.array([[2.0, 2.1]]) * ureg.eV)
+    band_structure_2 = ElectronicBandStructure(value=np.array([[2.0], [2.1]]) * ureg.eV)
     band_structure_2.k_path = _kline_path()
     output_2.electronic_band_structures.append(band_structure_2)
     simulation.outputs.append(output_2)
@@ -706,7 +715,9 @@ def test_data_schema_prefers_representative_system_outputs_for_electronic_proper
     output_rep = Outputs()
     output_rep.model_system_ref = representative_system
     output_rep.electronic_band_gaps.append(ElectronicBandGap(value=1.5 * ureg.eV))
-    band_structure_rep = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure_rep = ElectronicBandStructure(
+        value=np.array([[1.0], [1.1]]) * ureg.eV
+    )
     band_structure_rep.k_path = _kline_path()
     output_rep.electronic_band_structures.append(band_structure_rep)
     simulation.outputs.append(output_rep)
@@ -715,7 +726,7 @@ def test_data_schema_prefers_representative_system_outputs_for_electronic_proper
     output_other.model_system_ref = other_system
     output_other.electronic_band_gaps.append(ElectronicBandGap(value=2.5 * ureg.eV))
     band_structure_other = ElectronicBandStructure(
-        value=np.array([[2.0, 2.1]]) * ureg.eV
+        value=np.array([[2.0], [2.1]]) * ureg.eV
     )
     band_structure_other.k_path = _kline_path()
     output_other.electronic_band_structures.append(band_structure_other)
@@ -761,7 +772,7 @@ def test_data_schema_band_structure_mapping_creates_valid_segment_refs():
     simulation.model_system.append(model_system)
 
     output = Outputs()
-    band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     band_structure.k_path = _kline_path()
     output.electronic_band_structures.append(band_structure)
     simulation.outputs.append(output)
@@ -785,6 +796,7 @@ def test_data_schema_band_structure_mapping_creates_valid_segment_refs():
     assert str(segments[0]).startswith(
         '/run/0/calculation/0/band_structure_electronic/0/segment/'
     )
+    assert archive.m_resolve(str(segments[0])) is not None
 
 
 def test_data_schema_band_structure_uses_numerical_settings_kline_path_fallback():
@@ -823,7 +835,7 @@ def test_data_schema_band_structure_uses_numerical_settings_kline_path_fallback(
     simulation.model_system.append(model_system)
 
     output = Outputs()
-    band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     output.electronic_band_structures.append(band_structure)
     simulation.outputs.append(output)
     archive.data = simulation
@@ -874,7 +886,7 @@ def test_data_schema_band_structure_skips_non_kspace_numerical_settings():
     simulation.model_system.append(model_system)
 
     output = Outputs()
-    band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     output.electronic_band_structures.append(band_structure)
     simulation.outputs.append(output)
     archive.data = simulation
@@ -890,11 +902,8 @@ def test_data_schema_band_structure_skips_non_kspace_numerical_settings():
     assert np.array(segments[0].kpoints).shape[0] > 0
 
 
-def test_data_schema_band_structure_uses_kline_vertex_values_fallback():
-    """Band mapping should use high_symmetry_path_values fallback.
-
-    This fallback is used when k_line points are missing.
-    """
+def test_data_schema_band_structure_skips_ambiguous_vertex_only_path():
+    """Vertex-only paths must not be synthetically resampled onto energy points."""
     archive = EntryArchive(metadata=EntryMetadata())
     archive.results = Results()
     archive.results.properties = Properties()
@@ -930,7 +939,7 @@ def test_data_schema_band_structure_uses_kline_vertex_values_fallback():
     simulation.model_system.append(model_system)
 
     output = Outputs()
-    band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     output.electronic_band_structures.append(band_structure)
     simulation.outputs.append(output)
     archive.data = simulation
@@ -939,14 +948,7 @@ def test_data_schema_band_structure_uses_kline_vertex_values_fallback():
     normalizer.normalize(archive, LOGGER)
 
     electronic = archive.results.properties.electronic
-    assert electronic is not None
-    assert electronic.band_structure_electronic
-    segments = electronic.band_structure_electronic[0].segment
-    assert segments
-    assert (
-        np.array(segments[0].kpoints).shape[0]
-        == np.array(segments[0].energies.magnitude).shape[1]
-    )
+    assert electronic is None or not electronic.band_structure_electronic
 
 
 def test_data_schema_propagates_reference_energy_to_legacy_electronic_sections():
@@ -979,7 +981,7 @@ def test_data_schema_propagates_reference_energy_to_legacy_electronic_sections()
     reference_energy = 1.0 * ureg.eV
 
     output = Outputs()
-    band_structure = ElectronicBandStructure(value=np.array([[1.0, 1.1]]) * ureg.eV)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
     band_structure.k_path = _kline_path()
     band_structure.highest_occupied = reference_energy
     output.electronic_band_structures.append(band_structure)
@@ -1263,7 +1265,7 @@ def test_data_schema_does_not_create_empty_electronic_properties():
     model_system.periodic_boundary_conditions = [True, True, True]
     simulation.model_system.append(model_system)
 
-    output = Outputs()
+    output = TrajectoryOutputs(time=1.0 * ureg.ps)
     output.radii_of_gyration.append(SimRadiusOfGyration(value=1.2e-10 * ureg.meter))
     output.temperatures.append(SimTemperature(value=300 * ureg.kelvin))
     output.potential_energies.append(SimPotentialEnergy(value=-5.0 * ureg.eV))
@@ -1278,6 +1280,185 @@ def test_data_schema_does_not_create_empty_electronic_properties():
     assert archive.results.properties.structural.radius_of_gyration
     assert archive.results.properties.thermodynamic is not None
     assert archive.results.properties.thermodynamic.trajectory
+
+
+def test_data_schema_trajectory_uses_physical_time(archive_with_data_schema):
+    output = TrajectoryOutputs(time=2.5 * ureg.ps, wall_end=100 * ureg.s)
+    output.temperatures.append(SimTemperature(value=300 * ureg.kelvin))
+    archive_with_data_schema.data.outputs.append(output)
+
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    trajectory = archive_with_data_schema.results.properties.thermodynamic.trajectory[0]
+    time = trajectory.temperature.time.to('second').magnitude
+    assert np.asarray(time)[0] == pytest.approx(2.5e-12)
+
+
+def test_data_schema_does_not_merge_different_method_outputs(
+    archive_with_data_schema,
+):
+    simulation = archive_with_data_schema.data
+    system = simulation.model_system[0]
+    dft = DFT()
+    gw = GW()
+    simulation.model_method.extend([dft, gw])
+
+    dft_output = Outputs(model_system_ref=system, model_method_ref=dft)
+    dos = ElectronicDensityOfStates(value=np.array([0.1, 0.2]) / ureg.eV)
+    dos.energies = Energy2(points=np.array([-1.0, 1.0]) * ureg.eV)
+    dft_output.electronic_dos.append(dos)
+    simulation.outputs.append(dft_output)
+
+    gw_output = Outputs(model_system_ref=system, model_method_ref=gw)
+    band_structure = ElectronicBandStructure(value=np.array([[1.0], [1.1]]) * ureg.eV)
+    band_structure.k_path = _kline_path()
+    gw_output.electronic_band_structures.append(band_structure)
+    simulation.outputs.append(gw_output)
+
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    electronic = archive_with_data_schema.results.properties.electronic
+    assert electronic.band_structure_electronic
+    assert electronic.band_structure_electronic[0].label.endswith(':GW')
+    assert not electronic.dos_electronic
+
+
+@pytest.mark.skipif(not HAS_RUNSCHEMA, reason='requires runschema')
+def test_data_schema_preserves_legacy_calculation_and_result_sections():
+    archive = EntryArchive(
+        metadata=EntryMetadata(), results=Results(properties=Properties())
+    )
+
+    legacy_run = runschema.run.Run(raw_id='parser-owned')
+    legacy_calculation = runschema.calculation.Calculation()
+    legacy_dos = runschema.calculation.Dos(energies=np.array([-2.0, 2.0]) * ureg.eV)
+    legacy_dos.total.append(
+        runschema.calculation.DosValues(value=np.array([0.3, 0.4]) / ureg.eV)
+    )
+    legacy_calculation.dos_electronic.append(legacy_dos)
+    legacy_band_structure = runschema.calculation.BandStructure()
+    legacy_band_structure.segment.append(
+        runschema.calculation.BandEnergies(
+            energies=np.array([[[2.0], [2.1]]]) * ureg.eV,
+            kpoints=np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]]),
+        )
+    )
+    legacy_calculation.band_structure_electronic.append(legacy_band_structure)
+    legacy_run.calculation.append(legacy_calculation)
+    archive.run.append(legacy_run)
+
+    electronic = archive.results.properties.m_create(ElectronicProperties)
+    parser_dos = DOSElectronic(label='parser-owned')
+    parser_dos.energies = '/run/0/calculation/0/dos_electronic/0/energies'
+    parser_dos.total = ['/run/0/calculation/0/dos_electronic/0/total/0']
+    electronic.m_add_sub_section(ElectronicProperties.dos_electronic, parser_dos)
+    parser_band_structure = BandStructureElectronic(label='parser-owned')
+    parser_band_structure.segment = legacy_band_structure.segment
+    electronic.m_add_sub_section(
+        ElectronicProperties.band_structure_electronic, parser_band_structure
+    )
+    electronic.m_add_sub_section(
+        ElectronicProperties.band_gap, BandGap(value=9.0 * ureg.eV)
+    )
+
+    simulation = Simulation(program=Program(name='VASP'))
+    system = ModelSystem(is_representative=True, type='molecule')
+    simulation.model_system.append(system)
+    output = Outputs()
+    output.electronic_band_gaps.append(ElectronicBandGap(value=1.0 * ureg.eV))
+    mapped_dos = ElectronicDensityOfStates(value=np.array([0.1, 0.2]) / ureg.eV)
+    mapped_dos.energies = Energy2(points=np.array([-1.0, 1.0]) * ureg.eV)
+    output.electronic_dos.append(mapped_dos)
+    mapped_band_structure = ElectronicBandStructure(
+        value=np.array([[1.0], [1.1]]) * ureg.eV
+    )
+    mapped_band_structure.k_path = _kline_path()
+    output.electronic_band_structures.append(mapped_band_structure)
+    simulation.outputs.append(output)
+    archive.data = simulation
+
+    ResultsNormalizer().normalize(archive, LOGGER)
+
+    assert archive.run[0] is legacy_run
+    assert legacy_calculation.dos_electronic[0] is legacy_dos
+    assert legacy_calculation.band_structure_electronic[0] is legacy_band_structure
+    assert archive.run[1].raw_id == V2_COMPATIBILITY_RUN_ID
+    assert any(section.label == 'parser-owned' for section in electronic.dos_electronic)
+    assert any(
+        section.label == 'parser-owned'
+        for section in electronic.band_structure_electronic
+    )
+    assert any(gap.value.to('eV').magnitude == 9.0 for gap in electronic.band_gap)
+
+    serialized = archive.m_to_dict()
+    generated_dos = next(
+        section
+        for section in serialized['results']['properties']['electronic'][
+            'dos_electronic'
+        ]
+        if section.get('label', '').startswith('nomad-topology-normalizer:')
+    )
+    assert generated_dos['energies'].startswith('/run/1/calculation/0/')
+    assert all(
+        ref.startswith('/run/1/calculation/0/') for ref in generated_dos['total']
+    )
+    assert archive.m_resolve(generated_dos['energies']) is not None
+    assert all(archive.m_resolve(ref) is not None for ref in generated_dos['total'])
+
+
+def test_data_schema_output_mapping_is_idempotent(archive_with_data_schema):
+    output = TrajectoryOutputs(time=2.0 * ureg.ps)
+    absorption = AbsorptionSpectrum(value=np.array([0.5, 0.6]) / ureg.eV)
+    absorption.energies = Energy2(points=np.array([0.0, 1.0]) * ureg.eV)
+    output.absorption_spectra.append(absorption)
+    output.radii_of_gyration.append(SimRadiusOfGyration(value=1.2 * ureg.angstrom))
+    output.temperatures.append(SimTemperature(value=300 * ureg.kelvin))
+    archive_with_data_schema.data.outputs.append(output)
+
+    normalizer = ResultsNormalizer()
+    normalizer.normalize(archive_with_data_schema, LOGGER)
+    properties = archive_with_data_schema.results.properties
+    first_counts = (
+        len(properties.spectroscopic.spectra),
+        len(properties.structural.radius_of_gyration),
+        len(properties.thermodynamic.trajectory),
+    )
+    first_time = properties.thermodynamic.trajectory[0].temperature.time.copy()
+
+    normalizer.normalize(archive_with_data_schema, LOGGER)
+
+    assert (
+        len(properties.spectroscopic.spectra),
+        len(properties.structural.radius_of_gyration),
+        len(properties.thermodynamic.trajectory),
+    ) == first_counts
+    np.testing.assert_allclose(
+        properties.thermodynamic.trajectory[0].temperature.time,
+        first_time,
+    )
+
+
+def test_greens_mapping_does_not_create_axis_only_result():
+    if 'tau' not in GreensFunctionsElectronic.m_def.all_quantities:
+        pytest.skip('legacy Green functions fields unavailable')
+
+    greens = SimpleNamespace(
+        imaginary_time=None,
+        matsubara_frequency=None,
+        real_frequency=Frequency(points=np.array([0.0, 1.0]) * ureg.eV),
+        value=np.array([1.0 + 1.0j, 2.0 + 1.0j]) / ureg.eV,
+    )
+    output = SimpleNamespace(
+        electronic_greens_functions=[greens],
+        electronic_self_energies=[],
+        hybridization_functions=[],
+        quasiparticle_weights=[],
+        chemical_potentials=[],
+    )
+    normalizer = ResultsNormalizer()
+    normalizer.logger = LOGGER
+
+    assert normalizer._map_greens_functions(output) is None
 
 
 def test_data_schema_logs_unmapped_output_groups(archive_with_data_schema, caplog):

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -1295,9 +1295,34 @@ def test_data_schema_trajectory_uses_physical_time(archive_with_data_schema):
     assert np.asarray(time)[0] == pytest.approx(2.5e-12)
 
 
-def test_data_schema_does_not_merge_different_method_outputs(
+def test_data_schema_logs_trajectory_dropped_without_physical_time(
+    archive_with_data_schema, caplog
+):
+    """`time` only exists on TrajectoryOutputs; dropping it must not be silent."""
+    output = Outputs()
+    output.temperatures.append(SimTemperature(value=300 * ureg.kelvin))
+    output.potential_energies.append(SimPotentialEnergy(value=-5.0 * ureg.eV))
+    archive_with_data_schema.data.outputs.append(output)
+
+    caplog.clear()
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    thermodynamic = archive_with_data_schema.results.properties.thermodynamic
+    assert thermodynamic is None or not thermodynamic.trajectory
+    assert any(
+        'skipping trajectory series without physical time' in record.message
+        for record in caplog.records
+    )
+
+
+def test_data_schema_keeps_each_method_on_the_representative_system(
     archive_with_data_schema,
 ):
+    """DFT and GW results on one system are legacy-equivalent side-by-side data.
+
+    Legacy `get_gw_workflow_properties` publishes both, labelled; the v2 path
+    must not collapse them onto whichever output happens to come last.
+    """
     simulation = archive_with_data_schema.data
     system = simulation.model_system[0]
     dft = DFT()
@@ -1319,9 +1344,76 @@ def test_data_schema_does_not_merge_different_method_outputs(
     ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
 
     electronic = archive_with_data_schema.results.properties.electronic
-    assert electronic.band_structure_electronic
-    assert electronic.band_structure_electronic[0].label == 'GW'
-    assert not electronic.dos_electronic
+    assert [
+        band_structure.label for band_structure in electronic.band_structure_electronic
+    ] == ['GW']
+    assert [dos.label for dos in electronic.dos_electronic] == ['DFT']
+
+
+def test_data_schema_drops_outputs_from_non_representative_systems(
+    archive_with_data_schema, caplog
+):
+    """Merging outputs across different systems stays forbidden."""
+    simulation = archive_with_data_schema.data
+    representative_system = simulation.model_system[0]
+    other_system = ModelSystem(type='bulk')
+    simulation.model_system.append(other_system)
+
+    representative_output = Outputs(model_system_ref=representative_system)
+    representative_output.electronic_band_gaps.append(
+        ElectronicBandGap(value=1.5 * ureg.eV)
+    )
+    simulation.outputs.append(representative_output)
+
+    other_output = Outputs(model_system_ref=other_system)
+    other_output.electronic_band_gaps.append(ElectronicBandGap(value=2.5 * ureg.eV))
+    simulation.outputs.append(other_output)
+
+    caplog.clear()
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    electronic = archive_with_data_schema.results.properties.electronic
+    assert [band_gap.value.to('eV').magnitude for band_gap in electronic.band_gap] == [
+        1.5
+    ]
+    assert any(
+        'discarding electronic outputs from non-representative systems'
+        in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.skipif(not HAS_RUNSCHEMA, reason='requires runschema')
+def test_data_schema_gives_each_method_its_own_legacy_dos_references(
+    archive_with_data_schema,
+):
+    """Per-method DOS payloads must not overwrite each other's run references."""
+    simulation = archive_with_data_schema.data
+    system = simulation.model_system[0]
+    dft = DFT()
+    gw = GW()
+    simulation.model_method.extend([dft, gw])
+
+    for method, values in ((dft, [0.1, 0.2]), (gw, [0.3, 0.4])):
+        output = Outputs(model_system_ref=system, model_method_ref=method)
+        dos = ElectronicDensityOfStates(value=np.array(values) / ureg.eV)
+        dos.energies = Energy2(points=np.array([-1.0, 1.0]) * ureg.eV)
+        output.electronic_dos.append(dos)
+        simulation.outputs.append(output)
+
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    serialized = archive_with_data_schema.m_to_dict()
+    dos_sections = serialized['results']['properties']['electronic']['dos_electronic']
+    assert [section['label'] for section in dos_sections] == ['DFT', 'GW']
+
+    references = [section['energies'] for section in dos_sections]
+    references += [ref for section in dos_sections for ref in section['total']]
+    assert len(set(references)) == len(references)
+    assert all(
+        archive_with_data_schema.m_resolve(reference) is not None
+        for reference in references
+    )
 
 
 @pytest.mark.skipif(not HAS_RUNSCHEMA, reason='requires runschema')

--- a/tests/normalizers/test_symmetry_adapter.py
+++ b/tests/normalizers/test_symmetry_adapter.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
-from nomad.datamodel.results import Symmetry
+from nomad.datamodel.results import Symmetry, SymmetryNew
+from nomad_simulations.schema_packages.model_system import GlobalCrystalSymmetry
 
 from nomad_topology_normalizer.normalizers.symmetry_adapter import (
     apply_symmetry_data_to_results_symmetry,
@@ -125,6 +126,79 @@ def test_complete_model_system_symmetry_provides_legacy_material_id_inputs():
         find_model_system_representation(model_system, 'conventional') is conventional
     )
     assert has_complete_model_system_symmetry(model_system)
+
+
+def test_crystal_system_is_derived_from_v2_lattice_type():
+    """The real v2 section has no `crystal_system`; it must come from `lattice_type`.
+
+    Built from `GlobalCrystalSymmetry` rather than a namespace so that a schema
+    rename breaks this test instead of silently emptying a search field.
+    """
+    model_system = SimpleNamespace(
+        symmetry=GlobalCrystalSymmetry(
+            space_group_number=227,
+            space_group_symbol='Fd-3m',
+            point_group_symbol='m-3m',
+            lattice_type='c - cubic',
+            lattice_centering='F - all faces centred',
+        ),
+        local_symmetry=None,
+    )
+
+    symmetry_data = from_model_system(model_system)
+
+    assert symmetry_data['crystal_system'] == 'cubic'
+    assert symmetry_data['bravais_lattice'] == 'cF'
+
+    target = Symmetry()
+    apply_symmetry_data_to_results_symmetry(target, symmetry_data)
+    assert target.crystal_system == 'cubic'
+    assert target.bravais_lattice == 'cF'
+
+
+def test_two_dimensional_lattice_type_has_no_legacy_equivalent():
+    """2D Pearson symbols are not enum members and must not be assigned."""
+    model_system = SimpleNamespace(
+        symmetry=GlobalCrystalSymmetry(
+            space_group_number=1,
+            space_group_symbol='P1',
+            point_group_symbol='1',
+            lattice_type='mp - oblique',
+            lattice_centering='p - primitive 2D/1D',
+        ),
+        local_symmetry=None,
+    )
+
+    symmetry_data = from_model_system(model_system)
+
+    assert symmetry_data['crystal_system'] is None
+    assert symmetry_data['bravais_lattice'] is None
+
+    # Would raise on the MEnum quantity if an out-of-enum value leaked through.
+    apply_symmetry_data_to_results_symmetry(Symmetry(), symmetry_data)
+
+
+def test_prototype_id_reaches_topology_symmetry_section():
+    """Topology nodes use `SymmetryNew`, which names the AFLOW id differently."""
+    symmetry_data = from_model_system(
+        SimpleNamespace(
+            symmetry=GlobalCrystalSymmetry(
+                space_group_number=225,
+                space_group_symbol='Fm-3m',
+                point_group_symbol='m-3m',
+                prototype_aflow_id='AB_cF8_225_a_b',
+            ),
+            local_symmetry=None,
+        )
+    )
+
+    topology_symmetry = SymmetryNew()
+    apply_symmetry_data_to_results_symmetry(topology_symmetry, symmetry_data)
+    assert topology_symmetry.prototype_label_aflow == 'AB_cF8_225_a_b'
+
+    material_symmetry = Symmetry()
+    apply_symmetry_data_to_results_symmetry(material_symmetry, symmetry_data)
+    assert material_symmetry.prototype_aflow_id == 'AB_cF8_225_a_b'
 
 
 def test_incomplete_local_symmetry_does_not_invent_wyckoff_sets():

--- a/tests/normalizers/test_symmetry_adapter.py
+++ b/tests/normalizers/test_symmetry_adapter.py
@@ -4,9 +4,12 @@ from nomad.datamodel.results import Symmetry
 
 from nomad_topology_normalizer.normalizers.symmetry_adapter import (
     apply_symmetry_data_to_results_symmetry,
+    find_model_system_representation,
     from_legacy_repr_symmetry,
     from_model_system,
+    has_complete_model_system_symmetry,
     is_symmetry_data_minimally_complete,
+    wyckoff_sets_from_model_system,
 )
 
 
@@ -86,3 +89,52 @@ def test_apply_symmetry_data_to_results_symmetry_sets_available_fields():
     assert target.space_group_symbol == 'Pm-3m'
     assert target.point_group == 'm-3m'
     assert target.prototype_aflow_id == 'AB_cP2_221_a_b'
+
+
+def test_complete_model_system_symmetry_provides_legacy_material_id_inputs():
+    symmetry = SimpleNamespace(
+        space_group_number=166,
+        space_group_symbol='R-3m',
+        point_group_symbol='-3m',
+    )
+    local_symmetry = SimpleNamespace(
+        wyckoff_letters=['c', 'c'],
+        equivalent_atoms=[0, 0],
+        site_multiplicities=[6, 6],
+    )
+    conventional = SimpleNamespace(
+        name='conventional', lattice_vectors=[[8.0, 0.0, 0.0]] * 3
+    )
+    model_system = SimpleNamespace(
+        symmetry=symmetry,
+        local_symmetry=local_symmetry,
+        particle_states=[
+            SimpleNamespace(chemical_symbol='Si', atomic_number=14),
+            SimpleNamespace(chemical_symbol='Si', atomic_number=14),
+        ],
+        representations=[conventional],
+    )
+
+    wyckoff_sets = wyckoff_sets_from_model_system(model_system)
+
+    assert len(wyckoff_sets) == 1
+    assert wyckoff_sets[0].element == 'Si'
+    assert wyckoff_sets[0].wyckoff_letter == 'c'
+    assert len(wyckoff_sets[0].indices) == 6
+    assert (
+        find_model_system_representation(model_system, 'conventional') is conventional
+    )
+    assert has_complete_model_system_symmetry(model_system)
+
+
+def test_incomplete_local_symmetry_does_not_invent_wyckoff_sets():
+    model_system = SimpleNamespace(
+        local_symmetry=SimpleNamespace(
+            wyckoff_letters=['a'],
+            equivalent_atoms=None,
+            site_multiplicities=[1],
+        ),
+        particle_states=[SimpleNamespace(chemical_symbol='Si', atomic_number=14)],
+    )
+
+    assert wyckoff_sets_from_model_system(model_system) is None

--- a/tests/normalizers/test_topology_normalizer.py
+++ b/tests/normalizers/test_topology_normalizer.py
@@ -1028,9 +1028,65 @@ def test_topology_reuses_nomad_simulations_bulk_analysis(monkeypatch):
     assert material.material_id == expected_material_id
     assert conventional.material_id == material.material_id
     assert (
-        conventional.symmetry.space_group_number
-        == system.symmetry.space_group_number
+        conventional.symmetry.space_group_number == system.symmetry.space_group_number
     )
+    assert conventional.symmetry.crystal_system is not None
+
+
+def test_conventional_cell_publishes_viewer_geometry(monkeypatch):
+    """The structure viewer needs `atoms`; v2 representations carry no positions."""
+    archive = EntryArchive(metadata=EntryMetadata(), results=Results())
+    system = _make_bulk_model_system()
+    archive.data = Simulation(model_system=[system])
+    system.normalize(archive, LOGGER)
+
+    def fail_matid(*_args, **_kwargs):
+        raise AssertionError('topology normalizer fell back to the MatID topology')
+
+    monkeypatch.setattr(TopologyNormalizer, 'topology_matid', fail_matid)
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    conventional = next(
+        section
+        for section in archive.results.material.topology
+        if section.label == 'conventional cell'
+    )
+    expected_atoms = SymmetryAnalyzer(
+        system.to_ase_atoms(),
+        config.normalize.symmetry_tolerance,
+        config.normalize.flat_dim_threshold,
+    ).get_conventional_system()
+
+    assert conventional.atoms is not None
+    assert len(conventional.atoms.labels) == len(expected_atoms)
+    # n_atoms comes from the v2 Wyckoff multiplicities; it must agree with geometry.
+    assert conventional.n_atoms == len(expected_atoms)
+    assert conventional.cell.atomic_density is not None
+
+
+def test_conventional_cell_falls_back_when_viewer_geometry_is_unavailable(monkeypatch):
+    """A failed geometry recovery must not lose symmetry or material_id."""
+    archive = EntryArchive(metadata=EntryMetadata(), results=Results())
+    system = _make_bulk_model_system()
+    archive.data = Simulation(model_system=[system])
+    system.normalize(archive, LOGGER)
+
+    monkeypatch.setattr(
+        TopologyNormalizer, '_conventional_atoms_for_viewer', lambda _self: None
+    )
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    conventional = next(
+        section
+        for section in archive.results.material.topology
+        if section.label == 'conventional cell'
+    )
+    assert conventional.atoms is None
+    assert conventional.material_id is not None
+    assert conventional.cell is not None
+    assert conventional.symmetry.space_group_number is not None
 
 
 def test_complete_v2_bulk_symmetry_gets_material_id():

--- a/tests/normalizers/test_topology_normalizer.py
+++ b/tests/normalizers/test_topology_normalizer.py
@@ -915,7 +915,7 @@ def test_topology_bulk_uses_matid_for_material_id_fallback(monkeypatch):
     assert conv_system.material_id is not None
 
 
-def test_topology_skips_matid_for_bulk_with_complete_v2_symmetry(monkeypatch):
+def test_topology_runs_matid_for_bulk_with_complete_v2_symmetry(monkeypatch):
     archive = EntryArchive(metadata=EntryMetadata())
     archive.results = Results(material=Material(structural_type='bulk'))
     system = _make_bulk_model_system()
@@ -939,15 +939,39 @@ def test_topology_skips_matid_for_bulk_with_complete_v2_symmetry(monkeypatch):
 
     monkeypatch.setattr(normalizer, 'topology_calculation', lambda: None)
 
-    def fail_matid(_):
-        raise AssertionError('topology_matid should be skipped for complete v2 bulk')
+    called = {'value': False}
 
-    monkeypatch.setattr(normalizer, 'topology_matid', fail_matid)
+    def run_matid(_):
+        called['value'] = True
+        return ['topology-matid']
+
+    monkeypatch.setattr(normalizer, 'topology_matid', run_matid)
     monkeypatch.setattr(normalizer, 'topology_data', lambda *_: ['topology-data'])
 
     result = normalizer.topology(archive.results.material, system_v2=system)
 
-    assert result == ['topology-data']
+    assert called['value'] is True
+    assert result == ['topology-matid']
+
+
+def test_complete_v2_bulk_symmetry_gets_material_id():
+    archive = EntryArchive(metadata=EntryMetadata())
+    archive.results = Results(material=Material(structural_type='bulk'))
+    system = _make_bulk_model_system()
+    system.symmetry = SimpleNamespace(
+        hall_number=523,
+        hall_symbol='-F 4 2 3',
+        bravais_lattice='cF',
+        crystal_system='cubic',
+        space_group_number=225,
+        space_group_symbol='Fm-3m',
+        point_group_symbol='m-3m',
+    )
+    archive.data = Simulation(model_system=[system])
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    assert archive.results.material.material_id is not None
 
 
 def test_topology_runs_matid_for_bulk_with_incomplete_v2_symmetry(monkeypatch):

--- a/tests/normalizers/test_topology_normalizer.py
+++ b/tests/normalizers/test_topology_normalizer.py
@@ -2,7 +2,9 @@
 from types import SimpleNamespace
 
 import numpy as np
+from matid import SymmetryAnalyzer
 from nomad.client import normalize_all
+from nomad.config import config
 from nomad.datamodel import EntryArchive, EntryMetadata
 from nomad.datamodel.metainfo.workflow import Workflow
 from nomad.datamodel.results import Material, Relation, Results, System
@@ -10,8 +12,14 @@ from nomad.units import ureg
 from nomad.utils import get_logger
 from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.general import Simulation
-from nomad_simulations.schema_packages.model_system import ModelSystem
+from nomad_simulations.schema_packages.model_system import (
+    AlternativeRepresentation,
+    GlobalCrystalSymmetry,
+    LocalCrystalSymmetry,
+    ModelSystem,
+)
 
+from nomad_topology_normalizer.normalizers.common import material_id_bulk
 from nomad_topology_normalizer.normalizers.topology import (
     TopologyNormalizer,
     add_system,
@@ -28,6 +36,40 @@ def _make_bulk_model_system() -> ModelSystem:
     system.particle_states.append(AtomsState(chemical_symbol='Si', atomic_number=14))
     system.particle_states.append(AtomsState(chemical_symbol='Si', atomic_number=14))
     return system
+
+
+def _add_complete_v2_symmetry(system: ModelSystem) -> None:
+    """Populate the normalized symmetry inputs produced by nomad-simulations."""
+    system.symmetry = GlobalCrystalSymmetry(
+        hall_number=458,
+        hall_symbol='-R 3 2"',
+        lattice_type='h - hexagonal',
+        lattice_centering='R - rhombohedral',
+        space_group_number=166,
+        space_group_symbol='R-3m',
+        point_group_symbol='-3m',
+    )
+    system.local_symmetry = LocalCrystalSymmetry(
+        wyckoff_letters=['c', 'c'],
+        equivalent_atoms=[0, 0],
+        site_multiplicities=[6, 6],
+    )
+    system.representations.extend(
+        [
+            AlternativeRepresentation(
+                name='primitive',
+                crystal_cell_type='primitive',
+                lattice_vectors=np.eye(3) * 4.0 * ureg.angstrom,
+                periodic_boundary_conditions=[True, True, True],
+            ),
+            AlternativeRepresentation(
+                name='conventional',
+                crystal_cell_type='conventional',
+                lattice_vectors=np.eye(3) * 8.0 * ureg.angstrom,
+                periodic_boundary_conditions=[True, True, True],
+            ),
+        ]
+    )
 
 
 def test_topology_calculation():
@@ -915,19 +957,11 @@ def test_topology_bulk_uses_matid_for_material_id_fallback(monkeypatch):
     assert conv_system.material_id is not None
 
 
-def test_topology_runs_matid_for_bulk_with_complete_v2_symmetry(monkeypatch):
+def test_topology_consumes_complete_v2_bulk_symmetry_without_matid(monkeypatch):
     archive = EntryArchive(metadata=EntryMetadata())
     archive.results = Results(material=Material(structural_type='bulk'))
     system = _make_bulk_model_system()
-    system.symmetry = SimpleNamespace(
-        hall_number=523,
-        hall_symbol='-F 4 2 3',
-        bravais_lattice='cF',
-        crystal_system='cubic',
-        space_group_number=225,
-        space_group_symbol='Fm-3m',
-        point_group_symbol='m-3m',
-    )
+    _add_complete_v2_symmetry(system)
     simulation = Simulation()
     simulation.model_system.append(system)
     archive.data = simulation
@@ -939,34 +973,71 @@ def test_topology_runs_matid_for_bulk_with_complete_v2_symmetry(monkeypatch):
 
     monkeypatch.setattr(normalizer, 'topology_calculation', lambda: None)
 
-    called = {'value': False}
+    def fail_matid(_):
+        raise AssertionError('complete v2 symmetry must not invoke MatID fallback')
 
-    def run_matid(_):
-        called['value'] = True
-        return ['topology-matid']
-
-    monkeypatch.setattr(normalizer, 'topology_matid', run_matid)
+    monkeypatch.setattr(normalizer, 'topology_matid', fail_matid)
     monkeypatch.setattr(normalizer, 'topology_data', lambda *_: ['topology-data'])
 
     result = normalizer.topology(archive.results.material, system_v2=system)
 
-    assert called['value'] is True
-    assert result == ['topology-matid']
+    assert [section.label for section in result] == [
+        'original',
+        'subsystem',
+        'conventional cell',
+    ]
+    assert result[-1].material_id is not None
+    assert result[-1].symmetry.space_group_number == 166
+    assert result[-1].cell is not None
+    assert result[-1].cell.atomic_density is not None
+
+
+def test_topology_reuses_nomad_simulations_bulk_analysis(monkeypatch):
+    archive = EntryArchive(metadata=EntryMetadata(), results=Results())
+    system = _make_bulk_model_system()
+    archive.data = Simulation(model_system=[system])
+
+    # This is the authoritative simulation-layer symmetry normalization. The
+    # topology normalizer must consume its symmetry/local-symmetry/representations.
+    system.normalize(archive, LOGGER)
+    assert system.symmetry is not None
+    assert system.local_symmetry is not None
+    assert system.representations
+
+    legacy_analyzer = SymmetryAnalyzer(
+        system.to_ase_atoms(),
+        config.normalize.symmetry_tolerance,
+        config.normalize.flat_dim_threshold,
+    )
+    expected_material_id = material_id_bulk(
+        legacy_analyzer.get_space_group_number(),
+        legacy_analyzer.get_wyckoff_sets_conventional(),
+    )
+
+    def fail_matid(*_args, **_kwargs):
+        raise AssertionError('topology normalizer repeated MatID symmetry analysis')
+
+    monkeypatch.setattr(TopologyNormalizer, 'topology_matid', fail_matid)
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    material = archive.results.material
+    conventional = next(
+        section for section in material.topology if section.label == 'conventional cell'
+    )
+    assert material.material_id == expected_material_id
+    assert conventional.material_id == material.material_id
+    assert (
+        conventional.symmetry.space_group_number
+        == system.symmetry.space_group_number
+    )
 
 
 def test_complete_v2_bulk_symmetry_gets_material_id():
     archive = EntryArchive(metadata=EntryMetadata())
     archive.results = Results(material=Material(structural_type='bulk'))
     system = _make_bulk_model_system()
-    system.symmetry = SimpleNamespace(
-        hall_number=523,
-        hall_symbol='-F 4 2 3',
-        bravais_lattice='cF',
-        crystal_system='cubic',
-        space_group_number=225,
-        space_group_symbol='Fm-3m',
-        point_group_symbol='m-3m',
-    )
+    _add_complete_v2_symmetry(system)
     archive.data = Simulation(model_system=[system])
 
     TopologyNormalizer().normalize(archive, LOGGER)


### PR DESCRIPTION
Follow-up fixes for the `nomad-simulations` migration from #61, against `full-migration`.

## Dependency note

This branch requires `nomad-simulations` at or after
`144826f` ("Fix Wyckoff site_multiplicities (intrinsic) and use 4a notation",
#451). The bulk `material_id` path reads `local_symmetry.site_multiplicities`
as the intrinsic conventional-cell multiplicity. Against an older
`nomad-simulations` those counts mean something different and the resulting
`material_id` would be wrong. The distro currently pins an older commit.

## Symmetry fields that were silently unset

- `crystal_system` was never populated in the v2 path, in either
  `results.material.symmetry` or the topology conventional-cell symmetry.
  `GlobalCrystalSymmetry` has no such quantity; it carries `lattice_type`
  (`'c - cubic'`). Since `crystal_system` is Elasticsearch-indexed, migrated
  entries could not be filtered by it. Now derived from `lattice_type` and
  whitelisted against the legacy enum.
- The AFLOW prototype id never reached topology nodes. Those use `SymmetryNew`,
  which names the field `prototype_label_aflow`, while the adapter wrote
  `prototype_aflow_id` behind a `hasattr` guard. The name mismatch became a
  silent drop. Each source field now lists every legacy-equivalent target name.
- `bravais_lattice` on the v2 side is a Python property that also reconstructs
  2D/1D Pearson symbols such as `mpp`. Those are not members of the legacy
  `MEnum` and raised `ValueError` on assignment, aborting normalization for
  affected systems. They are now filtered out rather than assigned.

## Electronic properties

Outputs are grouped by `(model_system_ref, model_method_ref)`. Groups on the
representative system are all kept, one labelled section per method; a repeated
method keeps its most recent outputs. Groups belonging to other systems are
discarded with a warning, since results from different systems must not be
combined.

This restores legacy `get_gw_workflow_properties` behaviour, which publishes
DFT and GW results side by side. Previously a DFT+GW entry kept only whichever
output came last. Each method's DOS gets its own legacy `Dos` sections under the
compatibility calculation, indexed across the shared list so the references do
not collide.

## Data that is no longer published

- Band structures whose k-point and energy axes disagree are skipped instead of
  resampled. Interpolating over path vertices produced k-points unrelated to
  where the energies were actually computed. The `_resample_k_points` helper is
  removed. Note this makes the `high_symmetry_path_values` fallback unreachable
  in practice, since a vertex list is shorter than the sampled energy axis.
- Trajectories use simulated time rather than wall-clock. `time` exists only on
  `TrajectoryOutputs`, so plain `Outputs` produce no temperature or energy
  series. A time axis cannot be derived from the output index, so those series
  are dropped, and a warning now reports how many outputs were affected.
- Green's-function axes are written only together with their payload, so no
  section is produced carrying an axis with no data.

## Compatibility sections and ownership

- DOS and band-structure compatibility payloads go to a normalizer-owned run
  rather than `run[0]`. Previously the normalizer took the first run and cleared
  its `dos_electronic` and `band_structure_electronic`, which for a runschema
  parser meant destroying parser-produced data.
- Generated sections carry a `V2_COMPATIBILITY_ANNOTATION` marker in
  `m_annotations`. It is persisted in the archive, but it is not a quantity, so
  no user-facing field is claimed to hold bookkeeping. Re-normalization removes
  only marked sections, leaving parser-produced results intact.

  NOMAD reprocessing builds a fresh `EntryArchive`, so this is not a cross-run
  migration. It matters for archives that arrive already carrying `results`
  (`ArchiveParser` does not strip it) and for repeated normalization of the same
  archive object.

## Smaller fixes

- DOS validation no longer evaluates `energies in (None, '')`, which raised on
  numpy arrays.
- SCF thresholds accept both the current pint-quantity `threshold_change` and
  the older separate `threshold_change_unit` schema.
- `molecule` and `cluster` map to the supported `molecule / cluster` value.
- `m_unset` calls replaced with `m_set(name, None)`; `MSection` has no `m_unset`,
  so the previous code raised `AttributeError` inside an error handler.

## Topology waterfall change, worth a close look

A new step `topology_v2_symmetry()` is inserted between `topology_calculation()`
and `topology_matid()`. Bulk systems with complete v2 symmetry now build their
topology from the values `nomad-simulations` already normalized, instead of
re-running MatID symmetry analysis. The module docstring is updated.

**`material_id` is unchanged.** `test_topology_reuses_nomad_simulations_bulk_analysis`
runs the real `nomad-simulations` normalization, then computes
`material_id_bulk()` from a real `SymmetryAnalyzer`, and asserts the two agree.
This works because `get_symmetry_string` reads only `len(indices)`, and MatID
builds one Wyckoff set per `equivalent_atoms` orbit, which is what the adapter
reproduces.

The conventional-cell node still needs one `SymmetryAnalyzer` call, for geometry
only. The v2 conventional `Representation` carries `lattice_vectors` but neither
positions nor per-site species, so the structure viewer payload cannot be built
from v2 data alone. Symmetry and `material_id` are not recomputed. If the
recovered atom count disagrees with the v2 Wyckoff multiplicities, no `atoms`
are published rather than shipping a cell that contradicts `material_id`. This
can be dropped once `resolve_analyzed_cell` publishes conventional fractional
coordinates and atomic numbers upstream; there is a `TODO(migration)` marking it.

`topology_matid()` also now builds its own `SymmetryAnalyzer` for bulk systems
when no cached one is available, and propagates the resulting `material_id` up
to `results.material`.

## New Coverage

per-method electronic properties and DOS reference uniqueness,
cross-system rejection, physical trajectory time and the warning when it is
absent, idempotent re-normalization, parser-section preservation, vertex-only
band paths, Green's-function axis/payload pairing, `crystal_system` derivation,
2D lattice types, prototype id on both symmetry classes, symmetry consumption
without MatID recompute, and conventional-cell viewer geometry with its fallback.
