### PR TITLE
Run legacy results normalization before data-schema normalization

### DIFF
--- a/src/nomad_results_normalizer/normalizers/__init__.py
+++ b/src/nomad_results_normalizer/normalizers/__init__.py
@@ -4,9 +4,9 @@ from nomad.config.models.plugins import NormalizerEntryPoint
 class ResultsNormalizerEntryPoint(NormalizerEntryPoint):
     """Entry point for the Results normalizer with v2 data schema support.
 
-    This normalizer replaces the legacy ResultsNormalizer from nomad-FAIR
-    when v2 data schema is present. It automatically detects schema version
-    and routes to the appropriate normalization cascade.
+    This normalizer runs the legacy ResultsNormalizer from nomad-FAIR first,
+    then augments data-schema archives with results derived from
+    nomad-simulations data.
     """
 
     level: int = 3
@@ -58,7 +58,7 @@ class ResultsNormalizerEntryPoint(NormalizerEntryPoint):
 results_normalizer_plugin = ResultsNormalizerEntryPoint(
     name='Results',
     description=(
-        'Results normalizer with v2 data schema support and backward '
-        'compatibility for v1 run schema.'
+        'Results normalizer that runs legacy results normalization first and '
+        'adds nomad-simulations data-schema support.'
     ),
 )

--- a/src/nomad_results_normalizer/normalizers/results.py
+++ b/src/nomad_results_normalizer/normalizers/results.py
@@ -29,44 +29,41 @@ NORMALIZATION CASCADE ARCHITECTURE
 
 Plugin Entry Point: results_normalizer_plugin (level 3)
     │
-    └─── Schema Detection: _is_data_schema(archive)
+    ├─── Detect data-schema availability: _is_data_schema(archive)
+    │
+    ├─── Always attempt: _normalize_with_legacy()
+    │             │
+    │             └─ Delegates to
+    │                nomad.normalizing.results.ResultsNormalizer
+    │                   │
+    │                   └─ Handles: v1 run schema and existing NOMAD behavior
+    │
+    └─── Then, when data-schema is available:
             │
-            ├─ Checks: archive.data exists?
-            │          archive.data.model_system exists?
-            │
-            ├─ Data schema → _normalize_with_data_schema()
-            │                 │
-            │                 ├─ Initialize results sections
-            │                 └─ TopologyNormalizer.normalize()
-            │
-            └─ Legacy Schema → _normalize_with_legacy()
-                                  │
-                                  └─ Delegates to
-                                     nomad.normalizing.results.ResultsNormalizer
-                                        │
-                                        └─ Handles: v1 run schema
-                                                    Old data schemas
-                                                    Any other legacy formats
+            └─ Data schema → _normalize_with_data_schema()
+                              │
+                              ├─ Initialize results sections
+                              └─ TopologyNormalizer.normalize()
 
 Schema Version Detection
 ------------------------
 
-The _is_data_schema() method validates that an entry uses the
+The _is_data_schema() method checks whether an entry additionally uses the
 nomad-simulations data-schema path by checking:
 1. archive.data attribute exists
 2. archive.data.model_system attribute exists
 
-All other cases (including v1 run schema, old data schemas, or empty archives)
-are delegated to the legacy normalizer which handles them appropriately.
+All archives run legacy normalization. Entries with nomad-simulations data run
+the plugin's data-schema normalization afterward.
 
 Design Principles
 -----------------
 
-- Single entry point: Avoids double execution and cascade ordering issues
-- Precise detection: Only simulation data-schema archives trigger new path
-- Automatic fallback: Legacy handles all non-data-schema cases without explicit checks
+- Single entry point: Keeps legacy and data-schema result population ordered
+- Precise detection: Only simulation data-schema archives trigger the plugin pass
+- Backward compatibility: Legacy normalization still runs for all archives
 - Clean separation: data-schema code stays in plugin, legacy code stays in nomad-FAIR
-- No breaking changes: Existing entries continue to work via legacy path
+- No breaking changes: Existing entries continue to receive legacy results
 """
 
 import os
@@ -210,8 +207,9 @@ class ResultsNormalizerBase:
     The entry point creates a proper subclass dynamically. See class docstring above.
 
     Strategy:
-    1. Check if archive.data exists (data schema) → use new normalization cascade
-    2. If not, fall back to archive.run (v1 schema) → delegate to legacy normalizer
+    1. Always run the legacy NOMAD FAIR ResultsNormalizer first.
+    2. If nomad-simulations data is present, run the data-schema cascade after
+       legacy normalization to add/override data-schema-derived results.
 
     This ensures backward compatibility during the transition period.
     """
@@ -221,32 +219,33 @@ class ResultsNormalizerBase:
 
     def normalize(self, archive: EntryArchive, logger=None) -> None:
         self.entry_archive = archive
-        legacy_delegated = False
 
         # Setup logger
         if logger is not None:
             self.logger = logger.bind(normalizer=self.__class__.__name__)
 
-        # ========== LOGICAL SWITCH: simulation data schema vs legacy ==========
-        # Check if nomad-simulations data schema is present.
+        # ========== LOGICAL SWITCH: legacy baseline plus data-schema pass ==========
+        # Check first so a legacy failure does not prevent data-schema fallback.
         data_schema_info = self._is_data_schema(archive)
+
+        self.logger.info('Running legacy results normalization')
+        try:
+            self._normalize_with_legacy(archive, self.logger)
+        except Exception as error:
+            if not data_schema_info:
+                raise
+            self.logger.warning(
+                'Legacy results normalization failed before data-schema pass; '
+                'continuing with data-schema results normalization.',
+                exc_info=error,
+            )
 
         if data_schema_info:
             system_v2 = data_schema_info if data_schema_info is not True else None
-            # NEW PATH: Use data-schema normalization (this plugin)
-            self.logger.info('Using data-schema results normalization')
+            self.logger.info('Running data-schema results normalization')
             self._normalize_with_data_schema(archive, self.logger, system_v2)
         else:
-            # LEGACY PATH: Delegate to legacy normalizer (handles run schema,
-            # old data schema, etc.)
-            self.logger.info('Falling back to legacy results normalization')
-            self._normalize_with_legacy(archive, self.logger)
-            legacy_delegated = True
-
-        # Legacy delegate handles measurements itself.
-        if not legacy_delegated:
-            for measurement in self.entry_archive.measurement:
-                self.normalize_measurement(measurement)
+            self.logger.info('Skipping data-schema results normalization')
 
         self.entry_archive = None
         self.section_run = None
@@ -1707,11 +1706,11 @@ class ResultsNormalizerBase:
         self._log_unmapped_output_groups(outputs)
 
     def _normalize_with_legacy(self, archive: EntryArchive, logger) -> None:
-        """Normalization cascade for legacy schemas (v1 run schema, old data
-        schemas, etc.).
+        """Run the legacy NOMAD FAIR ResultsNormalizer baseline.
 
-        Delegates to the old ResultsNormalizer from nomad-FAIR which handles
-        all legacy cases.
+        This runs before the plugin data-schema pass so existing run-schema
+        behavior remains available when parsers populate both archive.run and
+        archive.data.
         """
         from nomad.normalizing.results import (
             ResultsNormalizer as LegacyResultsNormalizer,

--- a/src/nomad_results_normalizer/normalizers/topology.py
+++ b/src/nomad_results_normalizer/normalizers/topology.py
@@ -488,18 +488,42 @@ class TopologyNormalizer(Normalizer):
             ).material(populate_topology=False)
 
         if self.entry_archive.results and self.entry_archive.results.material:
-            topology = self.topology(self.entry_archive.results.material, system_v2)
+            material = self.entry_archive.results.material
+            existing_topology = list(material.topology or [])
+            material.topology = []
+            try:
+                topology = self.topology(material, system_v2)
+            except Exception:
+                material.topology = existing_topology
+                raise
             if topology:
-                self.entry_archive.results.material.topology.extend(topology)
+                if self._has_visualization_topology_payload(topology):
+                    material.topology.extend(topology)
+                elif existing_topology:
+                    self.logger.error(
+                        'Data-schema topology does not contain atoms or atoms_ref; '
+                        'restoring legacy topology for structure visualization.'
+                    )
+                    material.topology.extend(existing_topology)
+                else:
+                    self.logger.error(
+                        'Data-schema topology does not contain atoms or atoms_ref, '
+                        'and no legacy topology is available to restore.'
+                    )
+                    material.topology.extend(topology)
+            elif existing_topology:
+                material.topology.extend(existing_topology)
+
+    @staticmethod
+    def _has_visualization_topology_payload(topology: list[System]) -> bool:
+        return any(
+            getattr(system, 'atoms', None) is not None
+            or getattr(system, 'atoms_ref', None) is not None
+            for system in topology
+        )
 
     def topology(self, material, system_v2=None) -> list[System] | None:
         """Returns a dictionary that contains all of the topologies mapped by id."""
-        # If topology already exists (e.g. written by another normalizer), do
-        # not overwrite it.
-        topology = self.entry_archive.m_xpath('results.material.topology')
-        if topology:
-            return None
-
         # First: topology from data schema calculation (v2)
         topology = self.topology_calculation()
 

--- a/tests/normalizers/test_results_normalizer.py
+++ b/tests/normalizers/test_results_normalizer.py
@@ -184,7 +184,7 @@ def archive_empty():
 
 
 def test_schema_detection_data_schema(archive_with_data_schema, caplog):
-    """Test that the data schema is detected and routed correctly."""
+    """Data-schema archives should run legacy first, then the plugin path."""
     normalizer = ResultsNormalizer()
 
     # Clear any previous log records
@@ -193,21 +193,17 @@ def test_schema_detection_data_schema(archive_with_data_schema, caplog):
     # Run normalization
     normalizer.normalize(archive_with_data_schema, LOGGER)
 
-    # Check that the correct path was taken
-    # Look for the info log message
     assert any(
         'data-schema results normalization' in record.message
         for record in caplog.records
     ), 'Should log data-schema path'
-
-    # Should NOT see legacy message
-    assert not any(
+    assert any(
         'legacy results normalization' in record.message for record in caplog.records
-    ), 'Should not log legacy path'
+    ), 'Should log legacy path before data-schema path'
 
 
 def test_schema_detection_no_schema(archive_empty, caplog):
-    """Test behavior when neither data schema nor legacy schema is present."""
+    """Archives without data-schema content should only run legacy."""
     normalizer = ResultsNormalizer()
 
     # Clear any previous log records
@@ -220,10 +216,13 @@ def test_schema_detection_no_schema(archive_empty, caplog):
         # May fail without proper data - that's OK
         pass
 
-    # Should take legacy path (default fallback)
     assert any(
         'legacy results normalization' in record.message for record in caplog.records
-    ), 'Should log legacy path as fallback'
+    ), 'Should log legacy path'
+    assert any(
+        'Skipping data-schema results normalization' in record.message
+        for record in caplog.records
+    ), 'Should skip data-schema path when no nomad-simulations data exists'
 
 
 def test_non_simulation_data_schema_uses_legacy_path(caplog):
@@ -251,7 +250,7 @@ def test_non_simulation_data_schema_uses_legacy_path(caplog):
         'legacy results normalization' in record.message for record in caplog.records
     ), 'Non-simulation archive.data should use legacy path'
     assert not any(
-        'data-schema results normalization' in record.message
+        record.message == 'Running data-schema results normalization'
         for record in caplog.records
     ), 'Non-simulation archive.data should not use data-schema path'
 
@@ -1649,8 +1648,8 @@ def test_data_schema_skips_dos_cleanly_without_runschema(
         assert len(getattr(archive_with_data_schema, 'run', None) or []) == 0
 
 
-def test_data_schema_priority_over_run(archive_with_data_schema):
-    """Test that data schema takes priority when both schemas present."""
+def test_data_schema_runs_after_legacy_run(archive_with_data_schema):
+    """Data-schema normalization should run after legacy run normalization."""
     # Add a mock run section to the data schema archive
     from nomad.datamodel.data import ArchiveSection
 
@@ -1661,11 +1660,52 @@ def test_data_schema_priority_over_run(archive_with_data_schema):
 
     normalizer = ResultsNormalizer()
 
-    # Run normalization (should use data schema path, not run)
     normalizer.normalize(archive_with_data_schema, LOGGER)
 
-    # Should succeed without delegating to legacy normalizer
     assert archive_with_data_schema.results is not None
+
+
+def test_data_schema_runs_legacy_before_plugin(archive_with_data_schema, monkeypatch):
+    calls = []
+
+    def legacy(self, archive, logger):
+        calls.append('legacy')
+
+    def data_schema(self, archive, logger, system_v2=None):
+        calls.append('data-schema')
+
+    monkeypatch.setattr(ResultsNormalizer, '_normalize_with_legacy', legacy)
+    monkeypatch.setattr(ResultsNormalizer, '_normalize_with_data_schema', data_schema)
+
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    assert calls == ['legacy', 'data-schema']
+
+
+def test_data_schema_runs_plugin_after_legacy_failure(
+    archive_with_data_schema, monkeypatch, caplog
+):
+    calls = []
+
+    def legacy(self, archive, logger):
+        calls.append('legacy')
+        raise RuntimeError('legacy fixture failure')
+
+    def data_schema(self, archive, logger, system_v2=None):
+        calls.append('data-schema')
+
+    monkeypatch.setattr(ResultsNormalizer, '_normalize_with_legacy', legacy)
+    monkeypatch.setattr(ResultsNormalizer, '_normalize_with_data_schema', data_schema)
+    caplog.clear()
+
+    ResultsNormalizer().normalize(archive_with_data_schema, LOGGER)
+
+    assert calls == ['legacy', 'data-schema']
+    assert any(
+        'Legacy results normalization failed before data-schema pass'
+        in record.message
+        for record in caplog.records
+    )
 
 
 def test_data_schema_maps_geometry_optimization_workflow(archive_with_data_schema):
@@ -1856,7 +1896,7 @@ def test_normalize_with_data_schema_calls_topology_normalizer(
 def test_legacy_path_delegates_to_nomad_fair_results_normalizer(
     archive_empty, monkeypatch
 ):
-    """Legacy fallback should delegate to nomad-FAIR ResultsNormalizer."""
+    """Legacy baseline should delegate to nomad-FAIR ResultsNormalizer."""
     from nomad.normalizing.results import ResultsNormalizer as LegacyResultsNormalizer
 
     called = []

--- a/tests/normalizers/test_topology_normalizer.py
+++ b/tests/normalizers/test_topology_normalizer.py
@@ -19,7 +19,7 @@ from nomad_simulations.schema_packages.model_system import (
     ModelSystem,
 )
 
-from nomad_results_normalizer.normalizers.common import material_id_bulk
+from nomad_results_normalizer.normalizers.common import NOMADAtoms, material_id_bulk
 from nomad_results_normalizer.normalizers.symmetry_adapter import (
     wyckoff_sets_from_model_system,
 )
@@ -993,6 +993,86 @@ def test_topology_consumes_complete_v2_bulk_symmetry_without_matid(monkeypatch):
     assert result[-1].symmetry.space_group_number == 166
     assert result[-1].cell is not None
     assert result[-1].cell.atomic_density is not None
+
+
+def test_data_schema_topology_replaces_existing_legacy_topology(monkeypatch):
+    archive = EntryArchive(metadata=EntryMetadata())
+    archive.results = Results(material=Material())
+    archive.results.material.topology.append(
+        System(label='legacy', system_relation=Relation(type='root'))
+    )
+    archive.data = Simulation(model_system=[_make_bulk_model_system()])
+
+    def topology_calculation(_self):
+        atoms = NOMADAtoms(labels=['Si'])
+        return [
+            System(
+                label='data-schema',
+                system_relation=Relation(type='root'),
+                atoms=atoms,
+            )
+        ]
+
+    monkeypatch.setattr(
+        TopologyNormalizer, 'topology_calculation', topology_calculation
+    )
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    assert [system.label for system in archive.results.material.topology] == [
+        'data-schema'
+    ]
+
+
+def test_data_schema_topology_without_atoms_restores_existing_legacy_topology(
+    monkeypatch,
+    caplog,
+):
+    archive = EntryArchive(metadata=EntryMetadata())
+    archive.results = Results(material=Material())
+    archive.results.material.topology.append(
+        System(label='legacy', system_relation=Relation(type='root'))
+    )
+    archive.data = Simulation(model_system=[_make_bulk_model_system()])
+
+    def topology_calculation(_self):
+        return [System(label='data-schema', system_relation=Relation(type='root'))]
+
+    monkeypatch.setattr(
+        TopologyNormalizer, 'topology_calculation', topology_calculation
+    )
+    caplog.clear()
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    assert [system.label for system in archive.results.material.topology] == ['legacy']
+    assert any(
+        'Data-schema topology does not contain atoms or atoms_ref' in record.message
+        for record in caplog.records
+    )
+
+
+def test_data_schema_topology_restores_existing_legacy_topology_when_empty(
+    monkeypatch,
+):
+    archive = EntryArchive(metadata=EntryMetadata())
+    archive.results = Results(material=Material())
+    archive.results.material.topology.append(
+        System(label='legacy', system_relation=Relation(type='root'))
+    )
+    archive.data = Simulation(model_system=[_make_bulk_model_system()])
+
+    monkeypatch.setattr(TopologyNormalizer, 'topology_calculation', lambda _self: None)
+    monkeypatch.setattr(
+        TopologyNormalizer, 'topology_v2_symmetry', lambda _self, _material: None
+    )
+    monkeypatch.setattr(
+        TopologyNormalizer, 'topology_matid', lambda _self, _material: None
+    )
+
+    TopologyNormalizer().normalize(archive, LOGGER)
+
+    assert [system.label for system in archive.results.material.topology] == ['legacy']
 
 
 def test_topology_reuses_nomad_simulations_bulk_analysis(monkeypatch):


### PR DESCRIPTION
## Summary

This PR changes the results-normalizer flow so NOMAD FAIR legacy results normalization is always attempted first, and the plugin’s nomad-simulations data-schema normalization runs afterward when `archive.data` is available.

This lets archives that still populate `archive.run` keep legacy-derived results while allowing data-schema-derived results to overwrite or augment them.

## Behavior Changes

- Always attempts NOMAD FAIR’s legacy `ResultsNormalizer` first.
- Runs the plugin data-schema normalization afterward for nomad-simulations-style `archive.data`.
- If legacy normalization fails but data-schema content exists, logs a warning and continues with the data-schema pass.
- If no data-schema content exists, legacy failures still propagate.
- Data-schema topology is preferred over legacy topology only when it has minimum structure-visualization payload:
  - at least one topology node has `atoms`, or
  - at least one topology node has `atoms_ref`
- If data-schema topology is empty or lacks visualization payload, existing legacy topology is restored.

## Notes

This branch is intended as a flow change for mixed legacy/data-schema parser output. Full integration validation still needs parser setups that populate both `archive.run` and `archive.data`.

## Validation

```bash
python -m ruff check .
python -m pytest tests -q